### PR TITLE
[REFACTOR] 프로필 수정 API PATCH 방식 변경 및 응답 개선

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/profile/controller/ProfileController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/profile/controller/ProfileController.java
@@ -12,7 +12,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -46,17 +46,17 @@ public class ProfileController {
 
     /**
      * 프로필 수정
-     * PUT /api/v1/profile/me
+     * PATCH /api/v1/profile/me
      */
-    @PutMapping("/me")
-    public ResponseEntity<Void> updateProfile(
+    @PatchMapping("/me")
+    public ResponseEntity<ProfileResponseDto> updateProfile(
             @AuthenticationPrincipal Long userId,
             @RequestBody ProfileUpdateRequestDto request) {
         log.debug("프로필 수정 요청: userId={}", userId);
 
-        profileService.updateProfile(userId, request);
+        ProfileResponseDto updatedProfile = profileService.updateProfile(userId, request);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(updatedProfile);
     }
 
     /**

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/profile/service/ProfileService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/profile/service/ProfileService.java
@@ -19,6 +19,7 @@ public interface ProfileService {
      * 프로필 수정
      * @param userId 사용자 ID
      * @param request 수정 요청 DTO
+     * @return 수정된 프로필 정보
      */
-    void updateProfile(Long userId, ProfileUpdateRequestDto request);
+    ProfileResponseDto updateProfile(Long userId, ProfileUpdateRequestDto request);
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/profile/service/ProfileServiceImpl.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/profile/service/ProfileServiceImpl.java
@@ -81,7 +81,7 @@ public class ProfileServiceImpl implements ProfileService {
 
     @Override
     @Transactional
-    public void updateProfile(Long userId, ProfileUpdateRequestDto request) {
+    public ProfileResponseDto updateProfile(Long userId, ProfileUpdateRequestDto request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
@@ -94,6 +94,9 @@ public class ProfileServiceImpl implements ProfileService {
         if (hasContactInfo(request)) {
             updateContact(user, request);
         }
+
+        // 수정된 프로필 조회 후 반환
+        return getMyProfile(userId);
     }
 
     private void updateName(User user, String name) {

--- a/springboot/src/test/java/com/mzc/backend/lms/domains/user/profile/controller/ProfileControllerTest.java
+++ b/springboot/src/test/java/com/mzc/backend/lms/domains/user/profile/controller/ProfileControllerTest.java
@@ -173,13 +173,23 @@ class ProfileControllerTest {
                     .mobileNumber("010-9999-8888")
                     .build();
 
-            doNothing().when(profileService).updateProfile(userId, request);
+            ProfileResponseDto expectedResponse = ProfileResponseDto.builder()
+                    .userId(userId)
+                    .email("user@test.com")
+                    .name("새이름")
+                    .mobileNumber("010-9999-8888")
+                    .build();
+
+            when(profileService.updateProfile(userId, request)).thenReturn(expectedResponse);
 
             // when
-            ResponseEntity<Void> response = controller.updateProfile(userId, request);
+            ResponseEntity<ProfileResponseDto> response = controller.updateProfile(userId, request);
 
             // then
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getName()).isEqualTo("새이름");
+            assertThat(response.getBody().getMobileNumber()).isEqualTo("010-9999-8888");
             verify(profileService).updateProfile(userId, request);
         }
 
@@ -213,13 +223,21 @@ class ProfileControllerTest {
                     .name("새이름")
                     .build();
 
-            doNothing().when(profileService).updateProfile(userId, request);
+            ProfileResponseDto expectedResponse = ProfileResponseDto.builder()
+                    .userId(userId)
+                    .email("user@test.com")
+                    .name("새이름")
+                    .build();
+
+            when(profileService.updateProfile(userId, request)).thenReturn(expectedResponse);
 
             // when
-            ResponseEntity<Void> response = controller.updateProfile(userId, request);
+            ResponseEntity<ProfileResponseDto> response = controller.updateProfile(userId, request);
 
             // then
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getName()).isEqualTo("새이름");
             verify(profileService).updateProfile(userId, request);
         }
 
@@ -234,13 +252,23 @@ class ProfileControllerTest {
                     .officeNumber("02-3333-4444")
                     .build();
 
-            doNothing().when(profileService).updateProfile(userId, request);
+            ProfileResponseDto expectedResponse = ProfileResponseDto.builder()
+                    .userId(userId)
+                    .email("user@test.com")
+                    .mobileNumber("010-9999-8888")
+                    .homeNumber("02-1111-2222")
+                    .officeNumber("02-3333-4444")
+                    .build();
+
+            when(profileService.updateProfile(userId, request)).thenReturn(expectedResponse);
 
             // when
-            ResponseEntity<Void> response = controller.updateProfile(userId, request);
+            ResponseEntity<ProfileResponseDto> response = controller.updateProfile(userId, request);
 
             // then
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getMobileNumber()).isEqualTo("010-9999-8888");
             verify(profileService).updateProfile(userId, request);
         }
     }


### PR DESCRIPTION
## Summary
- HTTP Method를 PUT에서 PATCH로 변경 (부분 업데이트 시맨틱 적용)
- 수정 후 변경된 프로필 정보를 응답으로 반환
- 관련 테스트 코드 수정

## Test plan
- [ ] PATCH /api/v1/profile/me 요청 시 수정된 프로필 반환 확인
- [ ] 이름만 수정 시 정상 동작 확인
- [ ] 연락처만 수정 시 정상 동작 확인
- [ ] 이름 + 연락처 동시 수정 시 정상 동작 확인

Closes #57