### PR TITLE
#106[HOTFIX] JWT 토큰 만료 시 401 Unauthorized 응답 반환

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/common/config/SecurityConfig.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/common/config/SecurityConfig.java
@@ -1,9 +1,12 @@
 package com.mzc.backend.lms.common.config;
 
 import com.mzc.backend.lms.domains.user.auth.jwt.filter.JwtAuthenticationFilter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -15,6 +18,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Map;
 
 import java.util.Arrays;
 
@@ -65,7 +70,24 @@ public class SecurityConfig {
             )
 
             // JWT 필터 추가
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+
+            // 인증 실패 시 401 Unauthorized 응답
+            .exceptionHandling(exception -> exception
+                .authenticationEntryPoint((request, response, authException) -> {
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                    response.setCharacterEncoding("UTF-8");
+
+                    Map<String, Object> errorResponse = Map.of(
+                        "status", 401,
+                        "error", "Unauthorized",
+                        "message", "인증이 필요합니다. 토큰이 없거나 만료되었습니다."
+                    );
+
+                    new ObjectMapper().writeValue(response.getOutputStream(), errorResponse);
+                })
+            );
 
         return http.build();
     }


### PR DESCRIPTION
## Summary
- SecurityConfig에 `AuthenticationEntryPoint` 설정 추가
- 토큰 없음/만료 시 401 Unauthorized + JSON 응답 반환
- 기존: Spring Security 기본 동작(403 또는 리다이렉트)에 의존 → 수정: 명시적 401 응답

## 변경 사항
```java
.exceptionHandling(exception -> exception
    .authenticationEntryPoint((request, response, authException) -> {
        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
        // JSON 응답 반환
    })
)
```

## 응답 형식
```json
{
  "status": 401,
  "error": "Unauthorized",
  "message": "인증이 필요합니다. 토큰이 없거나 만료되었습니다."
}
```

## Test plan
- [ ] 토큰 없이 인증 필요 API 호출 → 401 응답 확인
- [ ] 만료된 토큰으로 API 호출 → 401 응답 확인
- [ ] 유효한 토큰으로 API 호출 → 정상 동작 확인

Closes #106