### PR TITLE
[Hotfix] 보안 설정 프로퍼티 경로 불일치 수정 (#120)

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/encryption/strategy/AES256EncryptionStrategy.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/encryption/strategy/AES256EncryptionStrategy.java
@@ -19,10 +19,10 @@ public class AES256EncryptionStrategy implements EncryptionStrategy {
     private static final String ALGORITHM = "AES/CBC/PKCS5Padding";
     private static final String AES = "AES";
 
-    @Value("${encryption.aes.secret-key:defaultSecretKey1234567890123456}")
+    @Value("${security.aes.encryption-key:defaultSecretKey1234567890123456}")
     private String secretKey;
 
-    @Value("${encryption.aes.iv:defaultIvParam456}")
+    @Value("${security.aes.iv:defaultIvParam456}")
     private String iv;
 
     /**

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/jwt/service/JwtTokenService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/jwt/service/JwtTokenService.java
@@ -25,13 +25,13 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class JwtTokenService {
 
-    @Value("${jwt.secret:defaultJwtSecretKeyForDevelopment123456789012345678901234567890}")
+    @Value("${security.jwt.secret:defaultJwtSecretKeyForDevelopment123456789012345678901234567890}")
     private String secretKey;
 
-    @Value("${jwt.access-token.expiration:1800000}") // 30분 (밀리초)
+    @Value("${security.jwt.access-token-expire-time:1800000}") // 30분 (밀리초)
     private Long accessTokenExpiration;
 
-    @Value("${jwt.refresh-token.expiration:604800000}") // 7일 (밀리초)
+    @Value("${security.jwt.refresh-token-expire-time:604800000}") // 7일 (밀리초)
     private Long refreshTokenExpiration;
 
     /**

--- a/springboot/src/main/resources/application-dev.yaml
+++ b/springboot/src/main/resources/application-dev.yaml
@@ -74,6 +74,7 @@ security:
     refresh-token-expire-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME}
   aes:
     encryption-key: ${ENCRYPTION_KEY}
+    iv: ${ENCRYPTION_IV:defaultIvParam456}
 
 logging:
   level:

--- a/springboot/src/main/resources/application-prod.yaml
+++ b/springboot/src/main/resources/application-prod.yaml
@@ -40,7 +40,8 @@ security:
     access-token-expire-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME}
     refresh-token-expire-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME}
   aes:
-    encryption-key: default-aes-encryption-key-change-in-production
+    encryption-key: ${ENCRYPTION_KEY:default-aes-encryption-key-change-in-production}
+    iv: ${ENCRYPTION_IV:defaultIvParam456}
 
 logging:
   level:


### PR DESCRIPTION
## Summary
- JWT 설정 프로퍼티 경로를 YAML 설정과 일치시킴
- AES 암호화 설정 프로퍼티 경로를 YAML 설정과 일치시킴
- YAML에 누락된 `security.aes.iv` 설정 추가

## Changes

### JWT (JwtTokenService.java)
| Before | After |
|--------|-------|
| `jwt.secret` | `security.jwt.secret` |
| `jwt.access-token.expiration` | `security.jwt.access-token-expire-time` |
| `jwt.refresh-token.expiration` | `security.jwt.refresh-token-expire-time` |

### AES (AES256EncryptionStrategy.java)
| Before | After |
|--------|-------|
| `encryption.aes.secret-key` | `security.aes.encryption-key` |
| `encryption.aes.iv` | `security.aes.iv` |

## Test plan
- [ ] 로그인 테스트 - JWT 토큰 정상 발급 확인
- [ ] 토큰 만료 시간이 설정값대로 적용되는지 확인
- [ ] AES 암호화/복호화 정상 동작 확인

Closes #120