### PR TITLE
#122[feature] Swagger(SpringDoc OpenAPI) 설정 추가

### DIFF
--- a/springboot/build.gradle
+++ b/springboot/build.gradle
@@ -70,6 +70,9 @@ dependencies {
     // ULID Generator
     implementation 'com.github.f4b6a3:ulid-creator:5.2.3'
 
+    // Swagger (SpringDoc OpenAPI)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
     //TEST
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/springboot/src/main/java/com/mzc/backend/lms/common/config/SecurityConfig.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/common/config/SecurityConfig.java
@@ -58,6 +58,8 @@ public class SecurityConfig {
                     "/health",
                     "/error",
                     "/swagger-ui/**",
+                    "/swagger-ui.html",
+                    "/swagger-resources/**",
                     "/v3/api-docs/**"
                 ).permitAll()
 

--- a/springboot/src/main/java/com/mzc/backend/lms/common/config/SwaggerConfig.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/common/config/SwaggerConfig.java
@@ -1,0 +1,40 @@
+package com.mzc.backend.lms.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "Bearer Authentication";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(apiInfo())
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME, securityScheme()));
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("MZC LMS API")
+                .description("MZC 1st Project - LMS Backend API Documentation")
+                .version("v1.0.0");
+    }
+
+    private SecurityScheme securityScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+    }
+}

--- a/springboot/src/main/resources/application.yaml
+++ b/springboot/src/main/resources/application.yaml
@@ -3,3 +3,11 @@ spring:
     active: dev
 server:
   port: ${SERVER_PORT:8080}
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha


### PR DESCRIPTION
## Summary
- springdoc-openapi-starter-webmvc-ui 의존성 추가
- SwaggerConfig 클래스 생성 (JWT 인증 스키마 포함)
- application.yaml에 springdoc 경로 설정 추가
- SecurityConfig에 swagger 관련 경로 허용 추가

## 접속 URL
- Swagger UI: `http://localhost:8080/swagger-ui.html`
- API Docs: `http://localhost:8080/v3/api-docs`

## Test plan
- [ ] 서버 실행 후 Swagger UI 접속 확인
- [ ] JWT 인증 스키마 동작 확인

closes #122