### PR TITLE
#124[feature] User 도메인 컨트롤러 Swagger 문서화

### DIFF
--- a/springboot/build.gradle
+++ b/springboot/build.gradle
@@ -70,6 +70,9 @@ dependencies {
     // ULID Generator
     implementation 'com.github.f4b6a3:ulid-creator:5.2.3'
 
+    // Swagger (SpringDoc OpenAPI)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
     //TEST
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/controller/AuthController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.mzc.backend.lms.domains.user.auth.controller;
 import com.mzc.backend.lms.domains.user.auth.dto.*;
 import com.mzc.backend.lms.domains.user.auth.email.service.EmailVerificationService;
 import com.mzc.backend.lms.domains.user.auth.service.AuthService;
+import com.mzc.backend.lms.domains.user.auth.swagger.AuthControllerSwagger;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,14 +22,12 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-public class AuthController {
+public class AuthController implements AuthControllerSwagger {
 
     private final AuthService authService;
     private final EmailVerificationService emailVerificationService;
 
-    /**
-     * 이메일 인증 코드 발송
-     */
+    @Override
     @PostMapping("/signup/email-verification")
     public ResponseEntity<?> sendVerificationCode(@Valid @RequestBody EmailVerificationRequestDto dto) {
         try {
@@ -48,9 +47,7 @@ public class AuthController {
         }
     }
 
-    /**
-     * 인증 코드 확인
-     */
+    @Override
     @PostMapping("/signup/verify-code")
     public ResponseEntity<?> verifyCode(@Valid @RequestBody VerifyCodeRequestDto dto) {
         try {
@@ -69,9 +66,7 @@ public class AuthController {
         }
     }
 
-    /**
-     * 회원가입
-     */
+    @Override
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@Valid @RequestBody SignupRequestDto dto) {
         try {
@@ -93,9 +88,7 @@ public class AuthController {
         }
     }
 
-    /**
-     * 로그인
-     */
+    @Override
     @PostMapping("/login")
     public ResponseEntity<?> login(@Valid @RequestBody LoginRequestDto dto,
                                   HttpServletRequest request) {
@@ -117,9 +110,7 @@ public class AuthController {
         }
     }
 
-    /**
-     * 토큰 갱신
-     */
+    @Override
     @PostMapping("/refresh")
     public ResponseEntity<?> refreshToken(@Valid @RequestBody RefreshTokenRequestDto dto) {
         try {
@@ -136,9 +127,7 @@ public class AuthController {
         }
     }
 
-    /**
-     * 로그아웃
-     */
+    @Override
     @PostMapping("/logout")
     public ResponseEntity<?> logout(@RequestHeader(value = "Refresh-Token", required = false) String refreshToken) {
         try {
@@ -154,9 +143,7 @@ public class AuthController {
         }
     }
 
-    /**
-     * 이메일 중복 확인
-     */
+    @Override
     @GetMapping("/check-email")
     public ResponseEntity<?> checkEmailAvailability(@RequestParam String email) {
         try {

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/swagger/AuthControllerSwagger.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/swagger/AuthControllerSwagger.java
@@ -1,0 +1,39 @@
+package com.mzc.backend.lms.domains.user.auth.swagger;
+
+import com.mzc.backend.lms.domains.user.auth.dto.EmailVerificationRequestDto;
+import com.mzc.backend.lms.domains.user.auth.dto.LoginRequestDto;
+import com.mzc.backend.lms.domains.user.auth.dto.RefreshTokenRequestDto;
+import com.mzc.backend.lms.domains.user.auth.dto.SignupRequestDto;
+import com.mzc.backend.lms.domains.user.auth.dto.VerifyCodeRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Auth", description = "인증 API")
+public interface AuthControllerSwagger {
+
+    @Operation(summary = "이메일 인증 코드 발송", description = "회원가입을 위한 이메일 인증 코드를 발송합니다")
+    ResponseEntity<?> sendVerificationCode(EmailVerificationRequestDto dto);
+
+    @Operation(summary = "인증 코드 확인", description = "발송된 이메일 인증 코드를 확인합니다")
+    ResponseEntity<?> verifyCode(VerifyCodeRequestDto dto);
+
+    @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다")
+    ResponseEntity<?> signup(SignupRequestDto dto);
+
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다")
+    ResponseEntity<?> login(LoginRequestDto dto, HttpServletRequest request);
+
+    @Operation(summary = "토큰 갱신", description = "Refresh Token을 사용하여 Access Token을 갱신합니다")
+    ResponseEntity<?> refreshToken(RefreshTokenRequestDto dto);
+
+    @Operation(summary = "로그아웃", description = "현재 세션을 로그아웃합니다")
+    ResponseEntity<?> logout(
+            @Parameter(description = "Refresh Token") String refreshToken);
+
+    @Operation(summary = "이메일 중복 확인", description = "이메일 사용 가능 여부를 확인합니다")
+    ResponseEntity<?> checkEmailAvailability(
+            @Parameter(description = "확인할 이메일 주소") String email);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/profile/controller/ProfileController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/profile/controller/ProfileController.java
@@ -4,6 +4,7 @@ import com.mzc.backend.lms.domains.user.profile.dto.ProfileResponseDto;
 import com.mzc.backend.lms.domains.user.profile.dto.ProfileUpdateRequestDto;
 import com.mzc.backend.lms.domains.user.profile.service.ProfileImageService;
 import com.mzc.backend.lms.domains.user.profile.service.ProfileService;
+import com.mzc.backend.lms.domains.user.profile.swagger.ProfileControllerSwagger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -26,15 +27,12 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/v1/profile")
 @RequiredArgsConstructor
-public class ProfileController {
+public class ProfileController implements ProfileControllerSwagger {
 
     private final ProfileService profileService;
     private final ProfileImageService profileImageService;
 
-    /**
-     * 내 프로필 조회
-     * GET /api/v1/profile/me
-     */
+    @Override
     @GetMapping("/me")
     public ResponseEntity<ProfileResponseDto> getMyProfile(@AuthenticationPrincipal Long userId) {
         log.debug("프로필 조회 요청: userId={}", userId);
@@ -44,10 +42,7 @@ public class ProfileController {
         return ResponseEntity.ok(profile);
     }
 
-    /**
-     * 프로필 수정
-     * PATCH /api/v1/profile/me
-     */
+    @Override
     @PatchMapping("/me")
     public ResponseEntity<ProfileResponseDto> updateProfile(
             @AuthenticationPrincipal Long userId,
@@ -59,10 +54,7 @@ public class ProfileController {
         return ResponseEntity.ok(updatedProfile);
     }
 
-    /**
-     * 프로필 이미지 업로드
-     * POST /api/v1/profile/me/image
-     */
+    @Override
     @PostMapping(value = "/me/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> uploadProfileImage(
             @AuthenticationPrincipal Long userId,
@@ -74,10 +66,7 @@ public class ProfileController {
         return ResponseEntity.accepted().build();
     }
 
-    /**
-     * 프로필 이미지 삭제
-     * DELETE /api/v1/profile/me/image
-     */
+    @Override
     @DeleteMapping("/me/image")
     public ResponseEntity<Void> deleteProfileImage(@AuthenticationPrincipal Long userId) {
         log.debug("프로필 이미지 삭제 요청: userId={}", userId);

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/profile/swagger/ProfileControllerSwagger.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/profile/swagger/ProfileControllerSwagger.java
@@ -1,0 +1,31 @@
+package com.mzc.backend.lms.domains.user.profile.swagger;
+
+import com.mzc.backend.lms.domains.user.profile.dto.ProfileResponseDto;
+import com.mzc.backend.lms.domains.user.profile.dto.ProfileUpdateRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "Profile", description = "프로필 API")
+public interface ProfileControllerSwagger {
+
+    @Operation(summary = "내 프로필 조회", description = "현재 로그인한 사용자의 프로필을 조회합니다")
+    ResponseEntity<ProfileResponseDto> getMyProfile(
+            @Parameter(hidden = true) Long userId);
+
+    @Operation(summary = "프로필 수정", description = "현재 로그인한 사용자의 프로필을 수정합니다")
+    ResponseEntity<ProfileResponseDto> updateProfile(
+            @Parameter(hidden = true) Long userId,
+            ProfileUpdateRequestDto request);
+
+    @Operation(summary = "프로필 이미지 업로드", description = "프로필 이미지를 업로드합니다")
+    ResponseEntity<Void> uploadProfileImage(
+            @Parameter(hidden = true) Long userId,
+            @Parameter(description = "업로드할 이미지 파일") MultipartFile file);
+
+    @Operation(summary = "프로필 이미지 삭제", description = "프로필 이미지를 삭제합니다")
+    ResponseEntity<Void> deleteProfileImage(
+            @Parameter(hidden = true) Long userId);
+}


### PR DESCRIPTION
## Summary
- AuthControllerSwagger 인터페이스 생성 및 AuthController에 적용
- ProfileControllerSwagger 인터페이스 생성 및 ProfileController에 적용
- springdoc-openapi 의존성 추가 (swagger 설정 PR과 중복될 수 있음)

## 변경 파일
- `auth/swagger/AuthControllerSwagger.java` (신규)
- `auth/controller/AuthController.java` (수정)
- `profile/swagger/ProfileControllerSwagger.java` (신규)
- `profile/controller/ProfileController.java` (수정)

## Test plan
- [ ] Swagger UI에서 Auth API 문서 확인
- [ ] Swagger UI에서 Profile API 문서 확인

closes #124