### PR TITLE
#129 유저 탐색 API 구현 (커서 기반 무한스크롤)

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/search/controller/UserSearchController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/search/controller/UserSearchController.java
@@ -1,0 +1,63 @@
+package com.mzc.backend.lms.domains.user.search.controller;
+
+import com.mzc.backend.lms.domains.user.search.dto.CollegeListResponseDto;
+import com.mzc.backend.lms.domains.user.search.dto.DepartmentListResponseDto;
+import com.mzc.backend.lms.domains.user.search.dto.UserSearchCursorResponseDto;
+import com.mzc.backend.lms.domains.user.search.dto.UserSearchRequestDto;
+import com.mzc.backend.lms.domains.user.search.service.UserSearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 유저 탐색 컨트롤러 (커서 기반 무한스크롤)
+ */
+@Tag(name = "User Search", description = "유저 탐색 API")
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserSearchController {
+
+    private final UserSearchService userSearchService;
+
+    @Operation(summary = "유저 탐색", description = "단과대, 학과, 이름, 사용자 타입으로 유저를 탐색합니다. (커서 기반 무한스크롤)")
+    @GetMapping("/search")
+    public ResponseEntity<UserSearchCursorResponseDto> searchUsers(
+            @Parameter(description = "검색 조건") @ModelAttribute UserSearchRequestDto request
+    ) {
+        UserSearchCursorResponseDto result = userSearchService.searchUsers(request);
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "단과대 목록 조회", description = "유저 탐색 필터용 단과대 목록을 조회합니다.")
+    @GetMapping("/colleges")
+    public ResponseEntity<List<CollegeListResponseDto>> getColleges() {
+        List<CollegeListResponseDto> result = userSearchService.getAllColleges();
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "학과 목록 조회 (단과대별)", description = "특정 단과대의 학과 목록을 조회합니다.")
+    @GetMapping("/colleges/{collegeId}/departments")
+    public ResponseEntity<List<DepartmentListResponseDto>> getDepartmentsByCollege(
+            @Parameter(description = "단과대 ID") @PathVariable Long collegeId
+    ) {
+        List<DepartmentListResponseDto> result = userSearchService.getDepartmentsByCollegeId(collegeId);
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "전체 학과 목록 조회", description = "모든 학과 목록을 조회합니다.")
+    @GetMapping("/departments")
+    public ResponseEntity<List<DepartmentListResponseDto>> getAllDepartments() {
+        List<DepartmentListResponseDto> result = userSearchService.getAllDepartments();
+        return ResponseEntity.ok(result);
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/search/dto/CollegeListResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/search/dto/CollegeListResponseDto.java
@@ -1,0 +1,27 @@
+package com.mzc.backend.lms.domains.user.search.dto;
+
+import com.mzc.backend.lms.domains.user.organization.entity.College;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 단과대 목록 응답 DTO (필터 선택용)
+ */
+@Getter
+@Builder
+public class CollegeListResponseDto {
+
+    private Long id;
+
+    private String collegeName;
+
+    private String collegeCode;
+
+    public static CollegeListResponseDto from(College college) {
+        return CollegeListResponseDto.builder()
+                .id(college.getId())
+                .collegeName(college.getCollegeName())
+                .collegeCode(college.getCollegeCode())
+                .build();
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/search/dto/DepartmentListResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/search/dto/DepartmentListResponseDto.java
@@ -1,0 +1,30 @@
+package com.mzc.backend.lms.domains.user.search.dto;
+
+import com.mzc.backend.lms.domains.user.organization.entity.Department;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 학과 목록 응답 DTO (필터 선택용)
+ */
+@Getter
+@Builder
+public class DepartmentListResponseDto {
+
+    private Long id;
+
+    private String departmentName;
+
+    private String departmentCode;
+
+    private Long collegeId;
+
+    public static DepartmentListResponseDto from(Department department) {
+        return DepartmentListResponseDto.builder()
+                .id(department.getId())
+                .departmentName(department.getDepartmentName())
+                .departmentCode(department.getDepartmentCode())
+                .collegeId(department.getCollege().getId())
+                .build();
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/search/dto/UserSearchCursorResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/search/dto/UserSearchCursorResponseDto.java
@@ -1,0 +1,52 @@
+package com.mzc.backend.lms.domains.user.search.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 유저 탐색 커서 기반 응답 DTO
+ */
+@Getter
+@Builder
+public class UserSearchCursorResponseDto {
+
+    private List<UserSearchResponseDto> content;
+
+    private Long nextCursorId;
+
+    private String nextCursorName;
+
+    private boolean hasNext;
+
+    public static UserSearchCursorResponseDto of(
+            List<UserSearchResponseDto> content,
+            int requestedSize,
+            UserSearchRequestDto.SortBy sortBy
+    ) {
+        boolean hasNext = content.size() > requestedSize;
+
+        List<UserSearchResponseDto> resultContent = hasNext
+                ? content.subList(0, requestedSize)
+                : content;
+
+        Long nextCursorId = null;
+        String nextCursorName = null;
+
+        if (!resultContent.isEmpty()) {
+            UserSearchResponseDto last = resultContent.get(resultContent.size() - 1);
+            nextCursorId = last.getUserId();
+            if (sortBy == UserSearchRequestDto.SortBy.NAME) {
+                nextCursorName = last.getName();
+            }
+        }
+
+        return UserSearchCursorResponseDto.builder()
+                .content(resultContent)
+                .nextCursorId(nextCursorId)
+                .nextCursorName(nextCursorName)
+                .hasNext(hasNext)
+                .build();
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/search/dto/UserSearchRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/search/dto/UserSearchRequestDto.java
@@ -1,0 +1,38 @@
+package com.mzc.backend.lms.domains.user.search.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 유저 탐색 요청 DTO (커서 기반 페이징)
+ */
+@Getter
+@Setter
+public class UserSearchRequestDto {
+
+    private Long collegeId;
+
+    private Long departmentId;
+
+    private String name;
+
+    private UserType userType;
+
+    private Long cursorId;
+
+    private String cursorName;
+
+    private Integer size = 20;
+
+    private SortBy sortBy = SortBy.ID;
+
+    public enum UserType {
+        STUDENT,
+        PROFESSOR
+    }
+
+    public enum SortBy {
+        ID,
+        NAME
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/search/dto/UserSearchResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/search/dto/UserSearchResponseDto.java
@@ -1,0 +1,48 @@
+package com.mzc.backend.lms.domains.user.search.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 유저 탐색 응답 DTO
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserSearchResponseDto {
+
+    private Long userId;
+
+    private String name;
+
+    private String email;
+
+    private String departmentName;
+
+    private String collegeName;
+
+    private String userType;
+
+    private String thumbnailUrl;
+
+    public static UserSearchResponseDto of(
+            Long userId,
+            String name,
+            String email,
+            String departmentName,
+            String collegeName,
+            String userType,
+            String thumbnailUrl
+    ) {
+        return UserSearchResponseDto.builder()
+                .userId(userId)
+                .name(name)
+                .email(email)
+                .departmentName(departmentName)
+                .collegeName(collegeName)
+                .userType(userType)
+                .thumbnailUrl(thumbnailUrl)
+                .build();
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/search/service/UserSearchService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/search/service/UserSearchService.java
@@ -1,0 +1,192 @@
+package com.mzc.backend.lms.domains.user.search.service;
+
+import com.mzc.backend.lms.domains.user.organization.repository.CollegeRepository;
+import com.mzc.backend.lms.domains.user.organization.repository.DepartmentRepository;
+import com.mzc.backend.lms.domains.user.search.dto.CollegeListResponseDto;
+import com.mzc.backend.lms.domains.user.search.dto.DepartmentListResponseDto;
+import com.mzc.backend.lms.domains.user.search.dto.UserSearchCursorResponseDto;
+import com.mzc.backend.lms.domains.user.search.dto.UserSearchRequestDto;
+import com.mzc.backend.lms.domains.user.search.dto.UserSearchRequestDto.SortBy;
+import com.mzc.backend.lms.domains.user.search.dto.UserSearchResponseDto;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 유저 탐색 서비스 (커서 기반 페이징)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserSearchService {
+
+    private final EntityManager entityManager;
+    private final CollegeRepository collegeRepository;
+    private final DepartmentRepository departmentRepository;
+
+    /**
+     * 유저 탐색 (커서 기반)
+     */
+    public UserSearchCursorResponseDto searchUsers(UserSearchRequestDto request) {
+        int size = request.getSize() != null ? request.getSize() : 20;
+        int fetchSize = size + 1;
+        SortBy sortBy = request.getSortBy() != null ? request.getSortBy() : SortBy.ID;
+
+        List<UserSearchResponseDto> results = new ArrayList<>();
+
+        if (request.getUserType() == null || request.getUserType() == UserSearchRequestDto.UserType.STUDENT) {
+            results.addAll(searchStudents(request, fetchSize, sortBy));
+        }
+
+        if (request.getUserType() == null || request.getUserType() == UserSearchRequestDto.UserType.PROFESSOR) {
+            results.addAll(searchProfessors(request, fetchSize, sortBy));
+        }
+
+        if (sortBy == SortBy.NAME) {
+            results.sort(Comparator.comparing(UserSearchResponseDto::getName, Comparator.nullsLast(Comparator.naturalOrder()))
+                    .thenComparing(UserSearchResponseDto::getUserId));
+        } else {
+            results.sort(Comparator.comparing(UserSearchResponseDto::getUserId));
+        }
+
+        if (results.size() > fetchSize) {
+            results = results.subList(0, fetchSize);
+        }
+
+        return UserSearchCursorResponseDto.of(results, size, sortBy);
+    }
+
+    private List<UserSearchResponseDto> searchStudents(UserSearchRequestDto request, int fetchSize, SortBy sortBy) {
+        StringBuilder jpql = new StringBuilder();
+        jpql.append("SELECT new com.mzc.backend.lms.domains.user.search.dto.UserSearchResponseDto(");
+        jpql.append("s.studentId, up.name, u.email, d.departmentName, c.collegeName, 'STUDENT', upi.thumbnailUrl) ");
+        jpql.append("FROM Student s ");
+        jpql.append("JOIN s.user u ");
+        jpql.append("LEFT JOIN UserProfile up ON up.user = u ");
+        jpql.append("LEFT JOIN UserProfileImage upi ON upi.user = u ");
+        jpql.append("LEFT JOIN StudentDepartment sd ON sd.student = s AND sd.isPrimary = true ");
+        jpql.append("LEFT JOIN sd.department d ");
+        jpql.append("LEFT JOIN d.college c ");
+        jpql.append("WHERE u.deletedAt IS NULL ");
+
+        Map<String, Object> params = new HashMap<>();
+
+        appendCursorCondition(jpql, params, request, sortBy, "s.studentId");
+        appendFilters(jpql, params, request);
+        appendOrderBy(jpql, sortBy, "s.studentId");
+
+        TypedQuery<UserSearchResponseDto> query = entityManager.createQuery(jpql.toString(), UserSearchResponseDto.class);
+        params.forEach(query::setParameter);
+        query.setMaxResults(fetchSize);
+
+        return query.getResultList();
+    }
+
+    private List<UserSearchResponseDto> searchProfessors(UserSearchRequestDto request, int fetchSize, SortBy sortBy) {
+        StringBuilder jpql = new StringBuilder();
+        jpql.append("SELECT new com.mzc.backend.lms.domains.user.search.dto.UserSearchResponseDto(");
+        jpql.append("p.professorId, up.name, u.email, d.departmentName, c.collegeName, 'PROFESSOR', upi.thumbnailUrl) ");
+        jpql.append("FROM Professor p ");
+        jpql.append("JOIN p.user u ");
+        jpql.append("LEFT JOIN UserProfile up ON up.user = u ");
+        jpql.append("LEFT JOIN UserProfileImage upi ON upi.user = u ");
+        jpql.append("LEFT JOIN ProfessorDepartment pd ON pd.professor = p AND pd.isPrimary = true ");
+        jpql.append("LEFT JOIN pd.department d ");
+        jpql.append("LEFT JOIN d.college c ");
+        jpql.append("WHERE u.deletedAt IS NULL ");
+
+        Map<String, Object> params = new HashMap<>();
+
+        appendCursorCondition(jpql, params, request, sortBy, "p.professorId");
+        appendFilters(jpql, params, request);
+        appendOrderBy(jpql, sortBy, "p.professorId");
+
+        TypedQuery<UserSearchResponseDto> query = entityManager.createQuery(jpql.toString(), UserSearchResponseDto.class);
+        params.forEach(query::setParameter);
+        query.setMaxResults(fetchSize);
+
+        return query.getResultList();
+    }
+
+    private void appendCursorCondition(StringBuilder jpql, Map<String, Object> params,
+                                       UserSearchRequestDto request, SortBy sortBy, String idField) {
+        if (sortBy == SortBy.NAME) {
+            if (request.getCursorName() != null && request.getCursorId() != null) {
+                jpql.append("AND (up.name > :cursorName OR (up.name = :cursorName AND ");
+                jpql.append(idField).append(" > :cursorId)) ");
+                params.put("cursorName", request.getCursorName());
+                params.put("cursorId", request.getCursorId());
+            } else if (request.getCursorName() != null) {
+                jpql.append("AND up.name > :cursorName ");
+                params.put("cursorName", request.getCursorName());
+            }
+        } else {
+            if (request.getCursorId() != null) {
+                jpql.append("AND ").append(idField).append(" > :cursorId ");
+                params.put("cursorId", request.getCursorId());
+            }
+        }
+    }
+
+    private void appendFilters(StringBuilder jpql, Map<String, Object> params, UserSearchRequestDto request) {
+        if (request.getCollegeId() != null) {
+            jpql.append("AND c.id = :collegeId ");
+            params.put("collegeId", request.getCollegeId());
+        }
+
+        if (request.getDepartmentId() != null) {
+            jpql.append("AND d.id = :departmentId ");
+            params.put("departmentId", request.getDepartmentId());
+        }
+
+        if (request.getName() != null && !request.getName().isBlank()) {
+            jpql.append("AND up.name LIKE :name ");
+            params.put("name", "%" + request.getName() + "%");
+        }
+    }
+
+    private void appendOrderBy(StringBuilder jpql, SortBy sortBy, String idField) {
+        if (sortBy == SortBy.NAME) {
+            jpql.append("ORDER BY up.name ASC, ").append(idField).append(" ASC");
+        } else {
+            jpql.append("ORDER BY ").append(idField).append(" ASC");
+        }
+    }
+
+    /**
+     * 전체 단과대 목록 조회 (필터 선택용)
+     */
+    public List<CollegeListResponseDto> getAllColleges() {
+        return collegeRepository.findAll().stream()
+                .map(CollegeListResponseDto::from)
+                .toList();
+    }
+
+    /**
+     * 단과대별 학과 목록 조회 (필터 선택용)
+     */
+    public List<DepartmentListResponseDto> getDepartmentsByCollegeId(Long collegeId) {
+        return departmentRepository.findByCollegeId(collegeId).stream()
+                .map(DepartmentListResponseDto::from)
+                .toList();
+    }
+
+    /**
+     * 전체 학과 목록 조회 (필터 선택용)
+     */
+    public List<DepartmentListResponseDto> getAllDepartments() {
+        return departmentRepository.findAll().stream()
+                .map(DepartmentListResponseDto::from)
+                .toList();
+    }
+}

--- a/springboot/src/main/resources/db/migration/V7__add_user_search_index.sql
+++ b/springboot/src/main/resources/db/migration/V7__add_user_search_index.sql
@@ -1,0 +1,4 @@
+-- 유저 탐색 기능을 위한 인덱스 추가
+-- 이름순 정렬 + 커서 기반 페이징 최적화
+
+CREATE INDEX idx_user_profiles_name_user_id ON user_profiles(name, user_id);


### PR DESCRIPTION
## Summary
- 유저 탐색 API 구현 (커서 기반 페이징, 무한스크롤 지원)
- 단과대/학과/이름/사용자타입 필터링 및 ID순/이름순 정렬 지원
- 단과대/학과 목록 조회 API 추가 (필터 드롭다운 UI용)
- 이름순 정렬 성능을 위한 DB 인덱스 추가

## Related Issue
- Closes #129

## API Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/v1/users/search` | 유저 탐색 (커서 기반) |
| GET | `/api/v1/users/colleges` | 단과대 목록 조회 |
| GET | `/api/v1/users/colleges/{id}/departments` | 단과대별 학과 목록 |
| GET | `/api/v1/users/departments` | 전체 학과 목록 |

## Test plan
- [ ] 유저 탐색 API 호출 테스트
- [ ] 필터 조합 테스트 (단과대, 학과, 이름, 사용자타입)
- [ ] 커서 기반 페이징 테스트
- [ ] 정렬 옵션 테스트 (ID순, 이름순)
- [ ] 단과대/학과 목록 조회 테스트