### PR TITLE
#130 대화방 관리 기능 구현

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/conversation/controller/ConversationController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/conversation/controller/ConversationController.java
@@ -1,0 +1,84 @@
+package com.mzc.backend.lms.domains.message.conversation.controller;
+
+import com.mzc.backend.lms.domains.message.conversation.dto.ConversationListResponseDto;
+import com.mzc.backend.lms.domains.message.conversation.dto.ConversationResponseDto;
+import com.mzc.backend.lms.domains.message.conversation.service.ConversationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 대화방 컨트롤러
+ */
+@Tag(name = "Conversation", description = "대화방 관리 API")
+@RestController
+@RequestMapping("/api/v1/conversations")
+@RequiredArgsConstructor
+public class ConversationController {
+
+    private final ConversationService conversationService;
+
+    @Operation(summary = "대화방 목록 조회", description = "내 대화방 목록을 조회합니다. (최근 메시지 순)")
+    @GetMapping
+    public ResponseEntity<List<ConversationListResponseDto>> getConversations(
+            @AuthenticationPrincipal Long userId
+    ) {
+        List<ConversationListResponseDto> result = conversationService.getConversations(userId);
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "대화방 조회/생성", description = "상대방과의 대화방을 조회하거나, 없으면 새로 생성합니다.")
+    @PostMapping("/with/{otherUserId}")
+    public ResponseEntity<ConversationResponseDto> getOrCreateConversation(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "상대방 ID") @PathVariable Long otherUserId
+    ) {
+        ConversationResponseDto result = conversationService.getOrCreateConversation(userId, otherUserId);
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "대화방 상세 조회", description = "특정 대화방 정보를 조회합니다.")
+    @GetMapping("/{conversationId}")
+    public ResponseEntity<ConversationResponseDto> getConversation(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "대화방 ID") @PathVariable Long conversationId
+    ) {
+        ConversationResponseDto result = conversationService.getConversation(conversationId, userId);
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "대화방 삭제", description = "대화방을 삭제합니다. (소프트 삭제, 양쪽 모두 삭제 시 완전 삭제)")
+    @DeleteMapping("/{conversationId}")
+    public ResponseEntity<Void> deleteConversation(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "대화방 ID") @PathVariable Long conversationId
+    ) {
+        conversationService.deleteConversation(conversationId, userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "대화방 읽음 처리", description = "대화방의 메시지를 모두 읽음 처리합니다.")
+    @PostMapping("/{conversationId}/read")
+    public ResponseEntity<Void> markAsRead(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "대화방 ID") @PathVariable Long conversationId
+    ) {
+        conversationService.markAsRead(conversationId, userId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "전체 안읽음 수 조회", description = "모든 대화방의 안읽음 메시지 수 합계를 조회합니다.")
+    @GetMapping("/unread-count")
+    public ResponseEntity<Integer> getTotalUnreadCount(
+            @AuthenticationPrincipal Long userId
+    ) {
+        int count = conversationService.getTotalUnreadCount(userId);
+        return ResponseEntity.ok(count);
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/conversation/dto/ConversationListResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/conversation/dto/ConversationListResponseDto.java
@@ -1,0 +1,51 @@
+package com.mzc.backend.lms.domains.message.conversation.dto;
+
+import com.mzc.backend.lms.domains.message.conversation.entity.Conversation;
+import com.mzc.backend.lms.domains.user.profile.entity.UserProfile;
+import com.mzc.backend.lms.domains.user.profile.entity.UserProfileImage;
+import com.mzc.backend.lms.domains.user.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 대화방 목록 응답 DTO
+ */
+@Getter
+@Builder
+public class ConversationListResponseDto {
+
+    private Long conversationId;
+
+    private Long otherUserId;
+
+    private String otherUserName;
+
+    private String otherUserThumbnailUrl;
+
+    private String lastMessageContent;
+
+    private LocalDateTime lastMessageAt;
+
+    private boolean isLastMessageMine;
+
+    private int unreadCount;
+
+    public static ConversationListResponseDto from(Conversation conversation, Long myUserId) {
+        User otherUser = conversation.getOtherUser(myUserId);
+        UserProfile otherProfile = otherUser.getUserProfile();
+        UserProfileImage otherProfileImage = otherUser.getProfileImage();
+
+        return ConversationListResponseDto.builder()
+                .conversationId(conversation.getId())
+                .otherUserId(otherUser.getId())
+                .otherUserName(otherProfile != null ? otherProfile.getName() : null)
+                .otherUserThumbnailUrl(otherProfileImage != null ? otherProfileImage.getThumbnailUrl() : null)
+                .lastMessageContent(conversation.getLastMessageContent())
+                .lastMessageAt(conversation.getLastMessageAt())
+                .isLastMessageMine(myUserId.equals(conversation.getLastMessageSenderId()))
+                .unreadCount(conversation.getUnreadCount(myUserId))
+                .build();
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/conversation/dto/ConversationResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/conversation/dto/ConversationResponseDto.java
@@ -1,0 +1,45 @@
+package com.mzc.backend.lms.domains.message.conversation.dto;
+
+import com.mzc.backend.lms.domains.message.conversation.entity.Conversation;
+import com.mzc.backend.lms.domains.user.profile.entity.UserProfile;
+import com.mzc.backend.lms.domains.user.profile.entity.UserProfileImage;
+import com.mzc.backend.lms.domains.user.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 대화방 상세 응답 DTO
+ */
+@Getter
+@Builder
+public class ConversationResponseDto {
+
+    private Long conversationId;
+
+    private Long otherUserId;
+
+    private String otherUserName;
+
+    private String otherUserEmail;
+
+    private String otherUserThumbnailUrl;
+
+    private LocalDateTime createdAt;
+
+    public static ConversationResponseDto from(Conversation conversation, Long myUserId) {
+        User otherUser = conversation.getOtherUser(myUserId);
+        UserProfile otherProfile = otherUser.getUserProfile();
+        UserProfileImage otherProfileImage = otherUser.getProfileImage();
+
+        return ConversationResponseDto.builder()
+                .conversationId(conversation.getId())
+                .otherUserId(otherUser.getId())
+                .otherUserName(otherProfile != null ? otherProfile.getName() : null)
+                .otherUserEmail(otherUser.getEmail())
+                .otherUserThumbnailUrl(otherProfileImage != null ? otherProfileImage.getThumbnailUrl() : null)
+                .createdAt(conversation.getCreatedAt())
+                .build();
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/conversation/entity/Conversation.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/conversation/entity/Conversation.java
@@ -1,0 +1,187 @@
+package com.mzc.backend.lms.domains.message.conversation.entity;
+
+import com.mzc.backend.lms.domains.user.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * 대화방 엔티티
+ * 1:1 대화방을 관리하며, 각 사용자별 삭제 상태와 안읽음 수를 추적
+ */
+@Entity
+@Table(name = "conversations", indexes = {
+    @Index(name = "idx_conversations_user1", columnList = "user1_id"),
+    @Index(name = "idx_conversations_user2", columnList = "user2_id"),
+    @Index(name = "idx_conversations_last_message_at", columnList = "last_message_at")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Conversation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user1_id", nullable = false)
+    private User user1;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user2_id", nullable = false)
+    private User user2;
+
+    @Column(name = "user1_unread_count", nullable = false)
+    private int user1UnreadCount = 0;
+
+    @Column(name = "user2_unread_count", nullable = false)
+    private int user2UnreadCount = 0;
+
+    @Column(name = "user1_deleted_at")
+    private LocalDateTime user1DeletedAt;
+
+    @Column(name = "user2_deleted_at")
+    private LocalDateTime user2DeletedAt;
+
+    @Column(name = "last_message_content", length = 500)
+    private String lastMessageContent;
+
+    @Column(name = "last_message_at")
+    private LocalDateTime lastMessageAt;
+
+    @Column(name = "last_message_sender_id")
+    private Long lastMessageSenderId;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private Conversation(User user1, User user2) {
+        this.user1 = user1;
+        this.user2 = user2;
+    }
+
+    /**
+     * 대화방 생성 (user1_id < user2_id 순서로 저장하여 중복 방지)
+     */
+    public static Conversation create(User userA, User userB) {
+        if (userA.getId() < userB.getId()) {
+            return Conversation.builder()
+                    .user1(userA)
+                    .user2(userB)
+                    .build();
+        } else {
+            return Conversation.builder()
+                    .user1(userB)
+                    .user2(userA)
+                    .build();
+        }
+    }
+
+    /**
+     * 마지막 메시지 업데이트
+     */
+    public void updateLastMessage(String content, Long senderId) {
+        this.lastMessageContent = content != null && content.length() > 500
+                ? content.substring(0, 500)
+                : content;
+        this.lastMessageAt = LocalDateTime.now();
+        this.lastMessageSenderId = senderId;
+
+        // 상대방 안읽음 수 증가
+        if (senderId.equals(user1.getId())) {
+            this.user2UnreadCount++;
+        } else {
+            this.user1UnreadCount++;
+        }
+
+        // 삭제된 대화방 복구 (새 메시지가 오면 다시 보이게)
+        if (senderId.equals(user1.getId()) && user2DeletedAt != null) {
+            this.user2DeletedAt = null;
+        } else if (senderId.equals(user2.getId()) && user1DeletedAt != null) {
+            this.user1DeletedAt = null;
+        }
+    }
+
+    /**
+     * 메시지 읽음 처리
+     */
+    public void markAsRead(Long userId) {
+        if (userId.equals(user1.getId())) {
+            this.user1UnreadCount = 0;
+        } else if (userId.equals(user2.getId())) {
+            this.user2UnreadCount = 0;
+        }
+    }
+
+    /**
+     * 대화방 삭제 (소프트 삭제)
+     */
+    public void deleteFor(Long userId) {
+        if (userId.equals(user1.getId())) {
+            this.user1DeletedAt = LocalDateTime.now();
+        } else if (userId.equals(user2.getId())) {
+            this.user2DeletedAt = LocalDateTime.now();
+        }
+    }
+
+    /**
+     * 대화방 복구
+     */
+    public void restoreFor(Long userId) {
+        if (userId.equals(user1.getId())) {
+            this.user1DeletedAt = null;
+        } else if (userId.equals(user2.getId())) {
+            this.user2DeletedAt = null;
+        }
+    }
+
+    /**
+     * 양쪽 모두 삭제했는지 확인
+     */
+    public boolean isDeletedByBoth() {
+        return user1DeletedAt != null && user2DeletedAt != null;
+    }
+
+    /**
+     * 특정 사용자에 대해 삭제되었는지 확인
+     */
+    public boolean isDeletedFor(Long userId) {
+        if (userId.equals(user1.getId())) {
+            return user1DeletedAt != null;
+        } else if (userId.equals(user2.getId())) {
+            return user2DeletedAt != null;
+        }
+        return false;
+    }
+
+    /**
+     * 상대방 조회
+     */
+    public User getOtherUser(Long myUserId) {
+        return myUserId.equals(user1.getId()) ? user2 : user1;
+    }
+
+    /**
+     * 안읽음 수 조회
+     */
+    public int getUnreadCount(Long userId) {
+        if (userId.equals(user1.getId())) {
+            return user1UnreadCount;
+        } else if (userId.equals(user2.getId())) {
+            return user2UnreadCount;
+        }
+        return 0;
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/conversation/repository/ConversationRepository.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/conversation/repository/ConversationRepository.java
@@ -1,0 +1,53 @@
+package com.mzc.backend.lms.domains.message.conversation.repository;
+
+import com.mzc.backend.lms.domains.message.conversation.entity.Conversation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 대화방 Repository
+ */
+@Repository
+public interface ConversationRepository extends JpaRepository<Conversation, Long> {
+
+    /**
+     * 두 사용자 간 대화방 조회 (user1_id < user2_id 순서로 저장됨)
+     */
+    @Query("SELECT c FROM Conversation c WHERE " +
+           "(c.user1.id = :smallerId AND c.user2.id = :largerId)")
+    Optional<Conversation> findByUsers(@Param("smallerId") Long smallerId, @Param("largerId") Long largerId);
+
+    /**
+     * 두 사용자 간 대화방 조회 (순서 무관)
+     */
+    default Optional<Conversation> findByTwoUsers(Long userId1, Long userId2) {
+        Long smallerId = Math.min(userId1, userId2);
+        Long largerId = Math.max(userId1, userId2);
+        return findByUsers(smallerId, largerId);
+    }
+
+    /**
+     * 사용자의 대화방 목록 조회 (삭제되지 않은 것만, 최근 메시지 순)
+     */
+    @Query("SELECT c FROM Conversation c " +
+           "WHERE (c.user1.id = :userId AND c.user1DeletedAt IS NULL) " +
+           "   OR (c.user2.id = :userId AND c.user2DeletedAt IS NULL) " +
+           "ORDER BY c.lastMessageAt DESC NULLS LAST")
+    List<Conversation> findByUserIdOrderByLastMessageAtDesc(@Param("userId") Long userId);
+
+    /**
+     * 사용자의 전체 안읽음 수 조회
+     */
+    @Query("SELECT COALESCE(SUM(CASE WHEN c.user1.id = :userId THEN c.user1UnreadCount " +
+           "                        WHEN c.user2.id = :userId THEN c.user2UnreadCount " +
+           "                        ELSE 0 END), 0) " +
+           "FROM Conversation c " +
+           "WHERE (c.user1.id = :userId AND c.user1DeletedAt IS NULL) " +
+           "   OR (c.user2.id = :userId AND c.user2DeletedAt IS NULL)")
+    int getTotalUnreadCount(@Param("userId") Long userId);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/conversation/service/ConversationService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/conversation/service/ConversationService.java
@@ -1,0 +1,132 @@
+package com.mzc.backend.lms.domains.message.conversation.service;
+
+import com.mzc.backend.lms.domains.message.conversation.dto.ConversationListResponseDto;
+import com.mzc.backend.lms.domains.message.conversation.dto.ConversationResponseDto;
+import com.mzc.backend.lms.domains.message.conversation.entity.Conversation;
+import com.mzc.backend.lms.domains.message.conversation.repository.ConversationRepository;
+import com.mzc.backend.lms.domains.user.user.entity.User;
+import com.mzc.backend.lms.domains.user.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 대화방 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ConversationService {
+
+    private final ConversationRepository conversationRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 대화방 목록 조회
+     */
+    public List<ConversationListResponseDto> getConversations(Long userId) {
+        List<Conversation> conversations = conversationRepository.findByUserIdOrderByLastMessageAtDesc(userId);
+
+        return conversations.stream()
+                .map(conversation -> ConversationListResponseDto.from(conversation, userId))
+                .toList();
+    }
+
+    /**
+     * 대화방 조회 또는 생성
+     * 기존 대화방이 있으면 반환, 없으면 새로 생성
+     */
+    @Transactional
+    public ConversationResponseDto getOrCreateConversation(Long myUserId, Long otherUserId) {
+        if (myUserId.equals(otherUserId)) {
+            throw new IllegalArgumentException("자기 자신과의 대화방은 생성할 수 없습니다.");
+        }
+
+        User myUser = userRepository.findActiveById(myUserId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + myUserId));
+
+        User otherUser = userRepository.findActiveById(otherUserId)
+                .orElseThrow(() -> new IllegalArgumentException("상대방을 찾을 수 없습니다: " + otherUserId));
+
+        Conversation conversation = conversationRepository.findByTwoUsers(myUserId, otherUserId)
+                .orElseGet(() -> {
+                    Conversation newConversation = Conversation.create(myUser, otherUser);
+                    return conversationRepository.save(newConversation);
+                });
+
+        // 삭제된 대화방이면 복구
+        if (conversation.isDeletedFor(myUserId)) {
+            conversation.restoreFor(myUserId);
+        }
+
+        return ConversationResponseDto.from(conversation, myUserId);
+    }
+
+    /**
+     * 대화방 상세 조회
+     */
+    public ConversationResponseDto getConversation(Long conversationId, Long userId) {
+        Conversation conversation = conversationRepository.findById(conversationId)
+                .orElseThrow(() -> new IllegalArgumentException("대화방을 찾을 수 없습니다: " + conversationId));
+
+        validateParticipant(conversation, userId);
+
+        if (conversation.isDeletedFor(userId)) {
+            throw new IllegalArgumentException("삭제된 대화방입니다.");
+        }
+
+        return ConversationResponseDto.from(conversation, userId);
+    }
+
+    /**
+     * 대화방 삭제 (소프트 삭제)
+     */
+    @Transactional
+    public void deleteConversation(Long conversationId, Long userId) {
+        Conversation conversation = conversationRepository.findById(conversationId)
+                .orElseThrow(() -> new IllegalArgumentException("대화방을 찾을 수 없습니다: " + conversationId));
+
+        validateParticipant(conversation, userId);
+
+        conversation.deleteFor(userId);
+
+        // 양쪽 모두 삭제했으면 하드 삭제
+        if (conversation.isDeletedByBoth()) {
+            conversationRepository.delete(conversation);
+            log.info("대화방 완전 삭제: conversationId={}", conversationId);
+        }
+    }
+
+    /**
+     * 메시지 읽음 처리
+     */
+    @Transactional
+    public void markAsRead(Long conversationId, Long userId) {
+        Conversation conversation = conversationRepository.findById(conversationId)
+                .orElseThrow(() -> new IllegalArgumentException("대화방을 찾을 수 없습니다: " + conversationId));
+
+        validateParticipant(conversation, userId);
+
+        conversation.markAsRead(userId);
+    }
+
+    /**
+     * 전체 안읽음 수 조회
+     */
+    public int getTotalUnreadCount(Long userId) {
+        return conversationRepository.getTotalUnreadCount(userId);
+    }
+
+    /**
+     * 대화방 참여자 검증
+     */
+    private void validateParticipant(Conversation conversation, Long userId) {
+        if (!userId.equals(conversation.getUser1().getId()) && !userId.equals(conversation.getUser2().getId())) {
+            throw new IllegalArgumentException("대화방에 참여하지 않은 사용자입니다.");
+        }
+    }
+}

--- a/springboot/src/main/resources/db/migration/V8__create_conversations_table.sql
+++ b/springboot/src/main/resources/db/migration/V8__create_conversations_table.sql
@@ -1,0 +1,25 @@
+-- 대화방 테이블 생성
+-- 1:1 대화방을 관리하며, 각 사용자별 삭제 상태와 안읽음 수를 추적
+
+CREATE TABLE conversations (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user1_id BIGINT NOT NULL,
+    user2_id BIGINT NOT NULL,
+    user1_unread_count INT NOT NULL DEFAULT 0,
+    user2_unread_count INT NOT NULL DEFAULT 0,
+    user1_deleted_at TIMESTAMP NULL,
+    user2_deleted_at TIMESTAMP NULL,
+    last_message_content VARCHAR(500) NULL,
+    last_message_at TIMESTAMP NULL,
+    last_message_sender_id BIGINT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_conversations_user1 FOREIGN KEY (user1_id) REFERENCES users(id),
+    CONSTRAINT fk_conversations_user2 FOREIGN KEY (user2_id) REFERENCES users(id),
+    CONSTRAINT uk_conversations_users UNIQUE (user1_id, user2_id),
+
+    INDEX idx_conversations_user1 (user1_id),
+    INDEX idx_conversations_user2 (user2_id),
+    INDEX idx_conversations_last_message_at (last_message_at DESC)
+);


### PR DESCRIPTION
## Summary
- 대화방 엔티티 및 테이블 설계 (V8 migration)
- 1:1 대화방 관리 API 구현 (목록, 생성, 조회, 삭제, 읽음 처리)
- 사용자별 안읽음 수 및 소프트 삭제 지원

## Related Issue
- Closes #130
- Epic: #128

## API Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/v1/conversations` | 대화방 목록 (최근 메시지 순) |
| POST | `/api/v1/conversations/with/{userId}` | 대화방 조회/생성 |
| GET | `/api/v1/conversations/{id}` | 대화방 상세 조회 |
| DELETE | `/api/v1/conversations/{id}` | 대화방 삭제 (소프트) |
| POST | `/api/v1/conversations/{id}/read` | 읽음 처리 |
| GET | `/api/v1/conversations/unread-count` | 전체 안읽음 수 |

## Test plan
- [ ] 대화방 목록 조회 테스트
- [ ] 대화방 생성/조회 테스트
- [ ] 기존 대화방 존재 시 재생성 방지 테스트
- [ ] 소프트 삭제 및 양쪽 삭제 시 하드 삭제 테스트
- [ ] 안읽음 수 증가/초기화 테스트