### PR TITLE
#131 메시지 송수신 기능 구현

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/conversation/controller/ConversationController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/conversation/controller/ConversationController.java
@@ -3,9 +3,7 @@ package com.mzc.backend.lms.domains.message.conversation.controller;
 import com.mzc.backend.lms.domains.message.conversation.dto.ConversationListResponseDto;
 import com.mzc.backend.lms.domains.message.conversation.dto.ConversationResponseDto;
 import com.mzc.backend.lms.domains.message.conversation.service.ConversationService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import com.mzc.backend.lms.domains.message.conversation.swagger.ConversationControllerSwagger;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,15 +14,14 @@ import java.util.List;
 /**
  * 대화방 컨트롤러
  */
-@Tag(name = "Conversation", description = "대화방 관리 API")
 @RestController
 @RequestMapping("/api/v1/conversations")
 @RequiredArgsConstructor
-public class ConversationController {
+public class ConversationController implements ConversationControllerSwagger {
 
     private final ConversationService conversationService;
 
-    @Operation(summary = "대화방 목록 조회", description = "내 대화방 목록을 조회합니다. (최근 메시지 순)")
+    @Override
     @GetMapping
     public ResponseEntity<List<ConversationListResponseDto>> getConversations(
             @AuthenticationPrincipal Long userId
@@ -33,47 +30,47 @@ public class ConversationController {
         return ResponseEntity.ok(result);
     }
 
-    @Operation(summary = "대화방 조회/생성", description = "상대방과의 대화방을 조회하거나, 없으면 새로 생성합니다.")
+    @Override
     @PostMapping("/with/{otherUserId}")
     public ResponseEntity<ConversationResponseDto> getOrCreateConversation(
             @AuthenticationPrincipal Long userId,
-            @Parameter(description = "상대방 ID") @PathVariable Long otherUserId
+            @PathVariable Long otherUserId
     ) {
         ConversationResponseDto result = conversationService.getOrCreateConversation(userId, otherUserId);
         return ResponseEntity.ok(result);
     }
 
-    @Operation(summary = "대화방 상세 조회", description = "특정 대화방 정보를 조회합니다.")
+    @Override
     @GetMapping("/{conversationId}")
     public ResponseEntity<ConversationResponseDto> getConversation(
             @AuthenticationPrincipal Long userId,
-            @Parameter(description = "대화방 ID") @PathVariable Long conversationId
+            @PathVariable Long conversationId
     ) {
         ConversationResponseDto result = conversationService.getConversation(conversationId, userId);
         return ResponseEntity.ok(result);
     }
 
-    @Operation(summary = "대화방 삭제", description = "대화방을 삭제합니다. (소프트 삭제, 양쪽 모두 삭제 시 완전 삭제)")
+    @Override
     @DeleteMapping("/{conversationId}")
     public ResponseEntity<Void> deleteConversation(
             @AuthenticationPrincipal Long userId,
-            @Parameter(description = "대화방 ID") @PathVariable Long conversationId
+            @PathVariable Long conversationId
     ) {
         conversationService.deleteConversation(conversationId, userId);
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "대화방 읽음 처리", description = "대화방의 메시지를 모두 읽음 처리합니다.")
+    @Override
     @PostMapping("/{conversationId}/read")
     public ResponseEntity<Void> markAsRead(
             @AuthenticationPrincipal Long userId,
-            @Parameter(description = "대화방 ID") @PathVariable Long conversationId
+            @PathVariable Long conversationId
     ) {
         conversationService.markAsRead(conversationId, userId);
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "전체 안읽음 수 조회", description = "모든 대화방의 안읽음 메시지 수 합계를 조회합니다.")
+    @Override
     @GetMapping("/unread-count")
     public ResponseEntity<Integer> getTotalUnreadCount(
             @AuthenticationPrincipal Long userId

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/conversation/swagger/ConversationControllerSwagger.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/conversation/swagger/ConversationControllerSwagger.java
@@ -1,0 +1,42 @@
+package com.mzc.backend.lms.domains.message.conversation.swagger;
+
+import com.mzc.backend.lms.domains.message.conversation.dto.ConversationListResponseDto;
+import com.mzc.backend.lms.domains.message.conversation.dto.ConversationResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Tag(name = "Conversation", description = "대화방 관리 API")
+public interface ConversationControllerSwagger {
+
+    @Operation(summary = "대화방 목록 조회", description = "내 대화방 목록을 조회합니다. (최근 메시지 순)")
+    ResponseEntity<List<ConversationListResponseDto>> getConversations(
+            @Parameter(hidden = true) Long userId);
+
+    @Operation(summary = "대화방 조회/생성", description = "상대방과의 대화방을 조회하거나, 없으면 새로 생성합니다.")
+    ResponseEntity<ConversationResponseDto> getOrCreateConversation(
+            @Parameter(hidden = true) Long userId,
+            @Parameter(description = "상대방 ID") Long otherUserId);
+
+    @Operation(summary = "대화방 상세 조회", description = "특정 대화방 정보를 조회합니다.")
+    ResponseEntity<ConversationResponseDto> getConversation(
+            @Parameter(hidden = true) Long userId,
+            @Parameter(description = "대화방 ID") Long conversationId);
+
+    @Operation(summary = "대화방 삭제", description = "대화방을 삭제합니다. (소프트 삭제, 양쪽 모두 삭제 시 완전 삭제)")
+    ResponseEntity<Void> deleteConversation(
+            @Parameter(hidden = true) Long userId,
+            @Parameter(description = "대화방 ID") Long conversationId);
+
+    @Operation(summary = "대화방 읽음 처리", description = "대화방의 메시지를 모두 읽음 처리합니다.")
+    ResponseEntity<Void> markAsRead(
+            @Parameter(hidden = true) Long userId,
+            @Parameter(description = "대화방 ID") Long conversationId);
+
+    @Operation(summary = "전체 안읽음 수 조회", description = "모든 대화방의 안읽음 메시지 수 합계를 조회합니다.")
+    ResponseEntity<Integer> getTotalUnreadCount(
+            @Parameter(hidden = true) Long userId);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/controller/MessageController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/controller/MessageController.java
@@ -1,0 +1,75 @@
+package com.mzc.backend.lms.domains.message.message.controller;
+
+import com.mzc.backend.lms.domains.message.message.dto.MessageBulkSendRequestDto;
+import com.mzc.backend.lms.domains.message.message.dto.MessageResponseDto;
+import com.mzc.backend.lms.domains.message.message.dto.MessageSendRequestDto;
+import com.mzc.backend.lms.domains.message.message.service.MessageService;
+import com.mzc.backend.lms.domains.message.message.swagger.MessageControllerSwagger;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 메시지 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/v1/messages")
+@RequiredArgsConstructor
+public class MessageController implements MessageControllerSwagger {
+
+    private final MessageService messageService;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<MessageResponseDto> sendMessage(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody MessageSendRequestDto request
+    ) {
+        MessageResponseDto result = messageService.sendMessage(userId, request);
+        return ResponseEntity.ok(result);
+    }
+
+    @Override
+    @PostMapping("/bulk")
+    public ResponseEntity<List<MessageResponseDto>> sendBulkMessages(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody MessageBulkSendRequestDto request
+    ) {
+        List<MessageResponseDto> results = messageService.sendBulkMessages(userId, request);
+        return ResponseEntity.ok(results);
+    }
+
+    @Override
+    @GetMapping("/conversations/{conversationId}")
+    public ResponseEntity<List<MessageResponseDto>> getMessages(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long conversationId
+    ) {
+        List<MessageResponseDto> results = messageService.getMessages(conversationId, userId);
+        return ResponseEntity.ok(results);
+    }
+
+    @Override
+    @DeleteMapping("/{messageId}")
+    public ResponseEntity<Void> deleteMessage(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long messageId
+    ) {
+        messageService.deleteMessage(messageId, userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    @PostMapping("/conversations/{conversationId}/read")
+    public ResponseEntity<Void> markMessagesAsRead(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long conversationId
+    ) {
+        messageService.markMessagesAsRead(conversationId, userId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/dto/MessageBulkSendRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/dto/MessageBulkSendRequestDto.java
@@ -1,0 +1,22 @@
+package com.mzc.backend.lms.domains.message.message.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * 다중 메시지 전송 요청 DTO (여러 사용자에게 각각 1:1 대화방으로 전송)
+ */
+@Getter
+@Setter
+public class MessageBulkSendRequestDto {
+
+    @NotEmpty(message = "수신자 목록은 필수입니다.")
+    private List<Long> receiverIds;
+
+    @NotBlank(message = "메시지 내용은 필수입니다.")
+    private String content;
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/dto/MessageResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/dto/MessageResponseDto.java
@@ -1,0 +1,44 @@
+package com.mzc.backend.lms.domains.message.message.dto;
+
+import com.mzc.backend.lms.domains.message.message.entity.Message;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 메시지 응답 DTO
+ */
+@Getter
+@Builder
+public class MessageResponseDto {
+
+    private Long messageId;
+
+    private Long senderId;
+
+    private String senderName;
+
+    private String content;
+
+    private boolean isMine;
+
+    private boolean isRead;
+
+    private LocalDateTime readAt;
+
+    private LocalDateTime createdAt;
+
+    public static MessageResponseDto from(Message message, Long myUserId, String senderName) {
+        return MessageResponseDto.builder()
+                .messageId(message.getId())
+                .senderId(message.getSenderId())
+                .senderName(senderName)
+                .content(message.getContent())
+                .isMine(myUserId.equals(message.getSenderId()))
+                .isRead(message.isRead())
+                .readAt(message.getReadAt())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/dto/MessageSendRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/dto/MessageSendRequestDto.java
@@ -1,0 +1,20 @@
+package com.mzc.backend.lms.domains.message.message.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 메시지 전송 요청 DTO
+ */
+@Getter
+@Setter
+public class MessageSendRequestDto {
+
+    @NotNull(message = "대화방 ID는 필수입니다.")
+    private Long conversationId;
+
+    @NotBlank(message = "메시지 내용은 필수입니다.")
+    private String content;
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/entity/Message.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/entity/Message.java
@@ -1,0 +1,142 @@
+package com.mzc.backend.lms.domains.message.message.entity;
+
+import com.mzc.backend.lms.domains.message.conversation.entity.Conversation;
+import com.mzc.backend.lms.domains.user.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * 메시지 엔티티
+ */
+@Entity
+@Table(name = "messages", indexes = {
+    @Index(name = "idx_messages_conversation_created", columnList = "conversation_id, created_at DESC"),
+    @Index(name = "idx_messages_sender", columnList = "sender_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Message {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "conversation_id", nullable = false)
+    private Conversation conversation;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender;
+
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    @Column(name = "deleted_by_sender", nullable = false)
+    private boolean deletedBySender = false;
+
+    @Column(name = "deleted_by_receiver", nullable = false)
+    private boolean deletedByReceiver = false;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    private Message(Conversation conversation, User sender, String content) {
+        this.conversation = conversation;
+        this.sender = sender;
+        this.content = content;
+    }
+
+    /**
+     * 메시지 생성
+     */
+    public static Message create(Conversation conversation, User sender, String content) {
+        return Message.builder()
+                .conversation(conversation)
+                .sender(sender)
+                .content(content)
+                .build();
+    }
+
+    /**
+     * 메시지 읽음 처리
+     */
+    public void markAsRead() {
+        if (this.readAt == null) {
+            this.readAt = LocalDateTime.now();
+        }
+    }
+
+    /**
+     * 읽음 여부 확인
+     */
+    public boolean isRead() {
+        return this.readAt != null;
+    }
+
+    /**
+     * 메시지 삭제 (발신자)
+     */
+    public void deleteBySender() {
+        this.deletedBySender = true;
+    }
+
+    /**
+     * 메시지 삭제 (수신자)
+     */
+    public void deleteByReceiver() {
+        this.deletedByReceiver = true;
+    }
+
+    /**
+     * 특정 사용자가 삭제했는지 확인
+     */
+    public boolean isDeletedBy(Long userId) {
+        if (userId.equals(sender.getId())) {
+            return deletedBySender;
+        } else {
+            return deletedByReceiver;
+        }
+    }
+
+    /**
+     * 양쪽 모두 삭제했는지 확인
+     */
+    public boolean isDeletedByBoth() {
+        return deletedBySender && deletedByReceiver;
+    }
+
+    /**
+     * 특정 사용자에게 보여야 하는지 확인
+     */
+    public boolean isVisibleTo(Long userId) {
+        return !isDeletedBy(userId);
+    }
+
+    /**
+     * 발신자 ID 조회
+     */
+    public Long getSenderId() {
+        return sender.getId();
+    }
+
+    /**
+     * 수신자 ID 조회
+     */
+    public Long getReceiverId() {
+        User user1 = conversation.getUser1();
+        User user2 = conversation.getUser2();
+        return sender.getId().equals(user1.getId()) ? user2.getId() : user1.getId();
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/repository/MessageRepository.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/repository/MessageRepository.java
@@ -1,0 +1,51 @@
+package com.mzc.backend.lms.domains.message.message.repository;
+
+import com.mzc.backend.lms.domains.message.message.entity.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * 메시지 Repository
+ */
+@Repository
+public interface MessageRepository extends JpaRepository<Message, Long> {
+
+    /**
+     * 대화방의 메시지 목록 조회 (최신순)
+     */
+    @Query("SELECT m FROM Message m " +
+           "WHERE m.conversation.id = :conversationId " +
+           "ORDER BY m.createdAt DESC")
+    List<Message> findByConversationIdOrderByCreatedAtDesc(@Param("conversationId") Long conversationId);
+
+    /**
+     * 대화방의 안읽은 메시지 읽음 처리 (수신자 기준)
+     */
+    @Modifying
+    @Query("UPDATE Message m SET m.readAt = CURRENT_TIMESTAMP " +
+           "WHERE m.conversation.id = :conversationId " +
+           "AND m.sender.id != :userId " +
+           "AND m.readAt IS NULL")
+    int markAllAsRead(@Param("conversationId") Long conversationId, @Param("userId") Long userId);
+
+    /**
+     * 양쪽 모두 삭제된 메시지 삭제
+     */
+    @Modifying
+    @Query("DELETE FROM Message m WHERE m.deletedBySender = true AND m.deletedByReceiver = true")
+    int deleteAllDeletedByBoth();
+
+    /**
+     * 대화방의 양쪽 모두 삭제된 메시지 삭제
+     */
+    @Modifying
+    @Query("DELETE FROM Message m " +
+           "WHERE m.conversation.id = :conversationId " +
+           "AND m.deletedBySender = true AND m.deletedByReceiver = true")
+    int deleteDeletedByBothInConversation(@Param("conversationId") Long conversationId);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/service/MessageService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/service/MessageService.java
@@ -1,0 +1,183 @@
+package com.mzc.backend.lms.domains.message.message.service;
+
+import com.mzc.backend.lms.domains.message.conversation.entity.Conversation;
+import com.mzc.backend.lms.domains.message.conversation.repository.ConversationRepository;
+import com.mzc.backend.lms.domains.message.message.dto.MessageBulkSendRequestDto;
+import com.mzc.backend.lms.domains.message.message.dto.MessageResponseDto;
+import com.mzc.backend.lms.domains.message.message.dto.MessageSendRequestDto;
+import com.mzc.backend.lms.domains.message.message.entity.Message;
+import com.mzc.backend.lms.domains.message.message.repository.MessageRepository;
+import com.mzc.backend.lms.domains.user.profile.entity.UserProfile;
+import com.mzc.backend.lms.domains.user.user.entity.User;
+import com.mzc.backend.lms.domains.user.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 메시지 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MessageService {
+
+    private final MessageRepository messageRepository;
+    private final ConversationRepository conversationRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 메시지 전송
+     */
+    @Transactional
+    public MessageResponseDto sendMessage(Long senderId, MessageSendRequestDto request) {
+        User sender = userRepository.findActiveById(senderId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + senderId));
+
+        Conversation conversation = conversationRepository.findById(request.getConversationId())
+                .orElseThrow(() -> new IllegalArgumentException("대화방을 찾을 수 없습니다: " + request.getConversationId()));
+
+        validateParticipant(conversation, senderId);
+
+        Message message = Message.create(conversation, sender, request.getContent());
+        messageRepository.save(message);
+
+        // 대화방 마지막 메시지 업데이트
+        conversation.updateLastMessage(request.getContent(), senderId);
+
+        String senderName = getSenderName(sender);
+        return MessageResponseDto.from(message, senderId, senderName);
+    }
+
+    /**
+     * 다중 메시지 전송 (여러 사용자에게 각각 1:1 대화방으로)
+     */
+    @Transactional
+    public List<MessageResponseDto> sendBulkMessages(Long senderId, MessageBulkSendRequestDto request) {
+        User sender = userRepository.findActiveById(senderId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + senderId));
+
+        List<MessageResponseDto> results = new ArrayList<>();
+        String senderName = getSenderName(sender);
+
+        for (Long receiverId : request.getReceiverIds()) {
+            if (senderId.equals(receiverId)) {
+                continue; // 자기 자신에게는 전송하지 않음
+            }
+
+            User receiver = userRepository.findActiveById(receiverId).orElse(null);
+            if (receiver == null) {
+                log.warn("수신자를 찾을 수 없습니다: {}", receiverId);
+                continue;
+            }
+
+            // 대화방 조회 또는 생성
+            Conversation conversation = conversationRepository.findByTwoUsers(senderId, receiverId)
+                    .orElseGet(() -> {
+                        Conversation newConversation = Conversation.create(sender, receiver);
+                        return conversationRepository.save(newConversation);
+                    });
+
+            // 삭제된 대화방이면 복구
+            if (conversation.isDeletedFor(senderId)) {
+                conversation.restoreFor(senderId);
+            }
+
+            // 메시지 생성 및 저장
+            Message message = Message.create(conversation, sender, request.getContent());
+            messageRepository.save(message);
+
+            // 대화방 마지막 메시지 업데이트
+            conversation.updateLastMessage(request.getContent(), senderId);
+
+            results.add(MessageResponseDto.from(message, senderId, senderName));
+        }
+
+        return results;
+    }
+
+    /**
+     * 대화방 메시지 목록 조회
+     */
+    public List<MessageResponseDto> getMessages(Long conversationId, Long userId) {
+        Conversation conversation = conversationRepository.findById(conversationId)
+                .orElseThrow(() -> new IllegalArgumentException("대화방을 찾을 수 없습니다: " + conversationId));
+
+        validateParticipant(conversation, userId);
+
+        List<Message> messages = messageRepository.findByConversationIdOrderByCreatedAtDesc(conversationId);
+
+        return messages.stream()
+                .filter(message -> message.isVisibleTo(userId))
+                .map(message -> {
+                    String senderName = getSenderName(message.getSender());
+                    return MessageResponseDto.from(message, userId, senderName);
+                })
+                .toList();
+    }
+
+    /**
+     * 메시지 삭제 (소프트 삭제)
+     */
+    @Transactional
+    public void deleteMessage(Long messageId, Long userId) {
+        Message message = messageRepository.findById(messageId)
+                .orElseThrow(() -> new IllegalArgumentException("메시지를 찾을 수 없습니다: " + messageId));
+
+        Conversation conversation = message.getConversation();
+        validateParticipant(conversation, userId);
+
+        if (userId.equals(message.getSenderId())) {
+            message.deleteBySender();
+        } else {
+            message.deleteByReceiver();
+        }
+
+        // 양쪽 모두 삭제했으면 하드 삭제
+        if (message.isDeletedByBoth()) {
+            messageRepository.delete(message);
+            log.info("메시지 완전 삭제: messageId={}", messageId);
+        }
+    }
+
+    /**
+     * 대화방 메시지 읽음 처리
+     */
+    @Transactional
+    public void markMessagesAsRead(Long conversationId, Long userId) {
+        Conversation conversation = conversationRepository.findById(conversationId)
+                .orElseThrow(() -> new IllegalArgumentException("대화방을 찾을 수 없습니다: " + conversationId));
+
+        validateParticipant(conversation, userId);
+
+        // 내가 수신한 메시지들 읽음 처리
+        int count = messageRepository.markAllAsRead(conversationId, userId);
+
+        // 대화방 안읽음 수 초기화
+        conversation.markAsRead(userId);
+
+        log.debug("메시지 읽음 처리: conversationId={}, userId={}, count={}", conversationId, userId, count);
+    }
+
+    /**
+     * 대화방 참여자 검증
+     */
+    private void validateParticipant(Conversation conversation, Long userId) {
+        if (!userId.equals(conversation.getUser1().getId()) && !userId.equals(conversation.getUser2().getId())) {
+            throw new IllegalArgumentException("대화방에 참여하지 않은 사용자입니다.");
+        }
+    }
+
+    /**
+     * 발신자 이름 조회
+     */
+    private String getSenderName(User sender) {
+        UserProfile profile = sender.getUserProfile();
+        return profile != null ? profile.getName() : null;
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/swagger/MessageControllerSwagger.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/swagger/MessageControllerSwagger.java
@@ -1,0 +1,40 @@
+package com.mzc.backend.lms.domains.message.message.swagger;
+
+import com.mzc.backend.lms.domains.message.message.dto.MessageBulkSendRequestDto;
+import com.mzc.backend.lms.domains.message.message.dto.MessageResponseDto;
+import com.mzc.backend.lms.domains.message.message.dto.MessageSendRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Tag(name = "Message", description = "메시지 송수신 API")
+public interface MessageControllerSwagger {
+
+    @Operation(summary = "메시지 전송", description = "대화방에 메시지를 전송합니다.")
+    ResponseEntity<MessageResponseDto> sendMessage(
+            @Parameter(hidden = true) Long userId,
+            MessageSendRequestDto request);
+
+    @Operation(summary = "다중 메시지 전송", description = "여러 사용자에게 각각 1:1 대화방으로 메시지를 전송합니다.")
+    ResponseEntity<List<MessageResponseDto>> sendBulkMessages(
+            @Parameter(hidden = true) Long userId,
+            MessageBulkSendRequestDto request);
+
+    @Operation(summary = "대화방 메시지 목록 조회", description = "대화방의 메시지 목록을 조회합니다. (최신순)")
+    ResponseEntity<List<MessageResponseDto>> getMessages(
+            @Parameter(hidden = true) Long userId,
+            @Parameter(description = "대화방 ID") Long conversationId);
+
+    @Operation(summary = "메시지 삭제", description = "메시지를 삭제합니다. (소프트 삭제, 양쪽 모두 삭제 시 완전 삭제)")
+    ResponseEntity<Void> deleteMessage(
+            @Parameter(hidden = true) Long userId,
+            @Parameter(description = "메시지 ID") Long messageId);
+
+    @Operation(summary = "대화방 메시지 읽음 처리", description = "대화방의 모든 메시지를 읽음 처리합니다.")
+    ResponseEntity<Void> markMessagesAsRead(
+            @Parameter(hidden = true) Long userId,
+            @Parameter(description = "대화방 ID") Long conversationId);
+}

--- a/springboot/src/main/resources/db/migration/V9__create_messages_table.sql
+++ b/springboot/src/main/resources/db/migration/V9__create_messages_table.sql
@@ -1,0 +1,19 @@
+-- 메시지 테이블 생성
+-- 대화방 내 메시지를 저장하며, 읽음 확인 및 소프트 삭제 지원
+
+CREATE TABLE messages (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    conversation_id BIGINT NOT NULL,
+    sender_id BIGINT NOT NULL,
+    content TEXT NOT NULL,
+    read_at TIMESTAMP NULL,
+    deleted_by_sender BOOLEAN NOT NULL DEFAULT FALSE,
+    deleted_by_receiver BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_messages_conversation FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE,
+    CONSTRAINT fk_messages_sender FOREIGN KEY (sender_id) REFERENCES users(id),
+
+    INDEX idx_messages_conversation_created (conversation_id, created_at DESC),
+    INDEX idx_messages_sender (sender_id)
+);


### PR DESCRIPTION
## Summary
- 메시지 엔티티 및 테이블 설계 (V9 migration)
- 메시지 송수신 API 구현 (전송, 다중 발송, 목록 조회, 삭제, 읽음 처리)
- 읽음 확인 및 소프트 삭제 지원
- Swagger 인터페이스 분리

## Related Issue
- Closes #131
- Epic: #128

## API Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/api/v1/messages` | 메시지 전송 |
| POST | `/api/v1/messages/bulk` | 다중 발송 |
| GET | `/api/v1/messages/conversations/{id}` | 메시지 목록 |
| DELETE | `/api/v1/messages/{id}` | 메시지 삭제 |
| POST | `/api/v1/messages/conversations/{id}/read` | 읽음 처리 |

## Test plan
- [ ] 메시지 전송 테스트
- [ ] 다중 발송 테스트
- [ ] 메시지 목록 조회 테스트
- [ ] 메시지 삭제 및 양쪽 삭제 시 하드 삭제 테스트
- [ ] 읽음 처리 테스트