### PR TITLE
#132 SSE 실시간 알림 기능 구현

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/sse/controller/SseController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/sse/controller/SseController.java
@@ -1,0 +1,28 @@
+package com.mzc.backend.lms.domains.message.sse.controller;
+
+import com.mzc.backend.lms.domains.message.sse.service.SseService;
+import com.mzc.backend.lms.domains.message.sse.swagger.SseControllerSwagger;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * SSE 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/v1/sse")
+@RequiredArgsConstructor
+public class SseController implements SseControllerSwagger {
+
+    private final SseService sseService;
+
+    @Override
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@AuthenticationPrincipal Long userId) {
+        return sseService.subscribe(userId);
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/sse/dto/MessageNotificationDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/sse/dto/MessageNotificationDto.java
@@ -1,0 +1,46 @@
+package com.mzc.backend.lms.domains.message.sse.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 메시지 알림 DTO (SSE 이벤트 페이로드)
+ */
+@Getter
+@Builder
+public class MessageNotificationDto {
+
+    private String type;
+
+    private Long conversationId;
+
+    private Long messageId;
+
+    private Long senderId;
+
+    private String senderName;
+
+    private String content;
+
+    private LocalDateTime createdAt;
+
+    public static MessageNotificationDto newMessage(
+            Long conversationId,
+            Long messageId,
+            Long senderId,
+            String senderName,
+            String content
+    ) {
+        return MessageNotificationDto.builder()
+                .type("NEW_MESSAGE")
+                .conversationId(conversationId)
+                .messageId(messageId)
+                .senderId(senderId)
+                .senderName(senderName)
+                .content(content.length() > 100 ? content.substring(0, 100) + "..." : content)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/sse/repository/SseEmitterRepository.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/sse/repository/SseEmitterRepository.java
@@ -1,0 +1,58 @@
+package com.mzc.backend.lms.domains.message.sse.repository;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * SSE Emitter 저장소
+ * 사용자별 SSE 연결을 관리
+ */
+@Slf4j
+@Repository
+public class SseEmitterRepository {
+
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    /**
+     * SSE Emitter 저장
+     */
+    public SseEmitter save(Long userId, SseEmitter emitter) {
+        emitters.put(userId, emitter);
+        log.debug("SSE 연결 저장: userId={}", userId);
+        return emitter;
+    }
+
+    /**
+     * SSE Emitter 조회
+     */
+    public Optional<SseEmitter> findByUserId(Long userId) {
+        return Optional.ofNullable(emitters.get(userId));
+    }
+
+    /**
+     * SSE Emitter 삭제
+     */
+    public void deleteByUserId(Long userId) {
+        emitters.remove(userId);
+        log.debug("SSE 연결 삭제: userId={}", userId);
+    }
+
+    /**
+     * 연결된 사용자 수 조회
+     */
+    public int getConnectionCount() {
+        return emitters.size();
+    }
+
+    /**
+     * 특정 사용자의 연결 여부 확인
+     */
+    public boolean isConnected(Long userId) {
+        return emitters.containsKey(userId);
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/sse/service/SseService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/sse/service/SseService.java
@@ -1,0 +1,85 @@
+package com.mzc.backend.lms.domains.message.sse.service;
+
+import com.mzc.backend.lms.domains.message.sse.dto.MessageNotificationDto;
+import com.mzc.backend.lms.domains.message.sse.repository.SseEmitterRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+
+/**
+ * SSE 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SseService {
+
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60; // 60분
+
+    private final SseEmitterRepository sseEmitterRepository;
+
+    /**
+     * SSE 연결 생성
+     */
+    public SseEmitter subscribe(Long userId) {
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+
+        sseEmitterRepository.save(userId, emitter);
+
+        emitter.onCompletion(() -> {
+            log.debug("SSE 연결 완료: userId={}", userId);
+            sseEmitterRepository.deleteByUserId(userId);
+        });
+
+        emitter.onTimeout(() -> {
+            log.debug("SSE 연결 타임아웃: userId={}", userId);
+            sseEmitterRepository.deleteByUserId(userId);
+        });
+
+        emitter.onError(e -> {
+            log.warn("SSE 연결 에러: userId={}, error={}", userId, e.getMessage());
+            sseEmitterRepository.deleteByUserId(userId);
+        });
+
+        // 연결 직후 더미 이벤트 전송 (연결 확인용)
+        sendToUser(userId, "connect", "connected");
+
+        log.info("SSE 연결 성공: userId={}", userId);
+        return emitter;
+    }
+
+    /**
+     * 특정 사용자에게 이벤트 전송
+     */
+    public void sendToUser(Long userId, String eventName, Object data) {
+        sseEmitterRepository.findByUserId(userId).ifPresent(emitter -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name(eventName)
+                        .data(data));
+            } catch (IOException e) {
+                log.warn("SSE 전송 실패: userId={}, error={}", userId, e.getMessage());
+                sseEmitterRepository.deleteByUserId(userId);
+            }
+        });
+    }
+
+    /**
+     * 새 메시지 알림 전송
+     */
+    public void sendNewMessageNotification(Long receiverId, MessageNotificationDto notification) {
+        sendToUser(receiverId, "message", notification);
+        log.debug("새 메시지 알림 전송: receiverId={}, messageId={}",
+                receiverId, notification.getMessageId());
+    }
+
+    /**
+     * 사용자 연결 여부 확인
+     */
+    public boolean isUserConnected(Long userId) {
+        return sseEmitterRepository.isConnected(userId);
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/sse/swagger/SseControllerSwagger.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/sse/swagger/SseControllerSwagger.java
@@ -1,0 +1,13 @@
+package com.mzc.backend.lms.domains.message.sse.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Tag(name = "SSE", description = "실시간 알림 API")
+public interface SseControllerSwagger {
+
+    @Operation(summary = "SSE 구독", description = "실시간 알림을 받기 위해 SSE 연결을 생성합니다.")
+    SseEmitter subscribe(@Parameter(hidden = true) Long userId);
+}


### PR DESCRIPTION
## Summary
- SSE 실시간 알림 인프라 구현
- 메시지 전송 시 수신자에게 실시간 알림 전송
- Swagger 인터페이스 분리

## Related Issue
- Closes #132
- Epic: #128

## API Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/v1/sse/subscribe` | SSE 구독 (실시간 알림 연결) |

## SSE Event Format
```json
{
  "type": "NEW_MESSAGE",
  "conversationId": 1,
  "messageId": 123,
  "senderId": 2024010001,
  "senderName": "홍길동",
  "content": "안녕하세요...",
  "createdAt": "2025-12-15T15:30:00"
}
```

## Test plan
- [ ] SSE 연결 테스트
- [ ] 메시지 전송 시 실시간 알림 수신 테스트
- [ ] 연결 타임아웃 후 재연결 테스트