### PR TITLE
#145[feature] 메시지 목록 커서 기반 페이징 구현

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/controller/MessageController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/controller/MessageController.java
@@ -1,6 +1,7 @@
 package com.mzc.backend.lms.domains.message.message.controller;
 
 import com.mzc.backend.lms.domains.message.message.dto.MessageBulkSendRequestDto;
+import com.mzc.backend.lms.domains.message.message.dto.MessageCursorResponseDto;
 import com.mzc.backend.lms.domains.message.message.dto.MessageResponseDto;
 import com.mzc.backend.lms.domains.message.message.dto.MessageSendRequestDto;
 import com.mzc.backend.lms.domains.message.message.service.MessageService;
@@ -45,12 +46,14 @@ public class MessageController implements MessageControllerSwagger {
 
     @Override
     @GetMapping("/conversations/{conversationId}")
-    public ResponseEntity<List<MessageResponseDto>> getMessages(
+    public ResponseEntity<MessageCursorResponseDto> getMessages(
             @AuthenticationPrincipal Long userId,
-            @PathVariable Long conversationId
+            @PathVariable Long conversationId,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(required = false, defaultValue = "20") Integer size
     ) {
-        List<MessageResponseDto> results = messageService.getMessages(conversationId, userId);
-        return ResponseEntity.ok(results);
+        MessageCursorResponseDto result = messageService.getMessages(conversationId, userId, cursor, size);
+        return ResponseEntity.ok(result);
     }
 
     @Override

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/dto/MessageCursorResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/dto/MessageCursorResponseDto.java
@@ -1,0 +1,39 @@
+package com.mzc.backend.lms.domains.message.message.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 메시지 목록 커서 페이징 응답 DTO.
+ */
+@Getter
+@Builder
+public class MessageCursorResponseDto {
+
+    private List<MessageResponseDto> messages;
+
+    private Long nextCursor;
+
+    private boolean hasMore;
+
+    public static MessageCursorResponseDto of(List<MessageResponseDto> messages, int requestedSize) {
+        boolean hasMore = messages.size() > requestedSize;
+
+        List<MessageResponseDto> resultMessages = hasMore
+                ? messages.subList(0, requestedSize)
+                : messages;
+
+        Long nextCursor = null;
+        if (hasMore && !resultMessages.isEmpty()) {
+            nextCursor = resultMessages.get(resultMessages.size() - 1).getMessageId();
+        }
+
+        return MessageCursorResponseDto.builder()
+                .messages(resultMessages)
+                .nextCursor(nextCursor)
+                .hasMore(hasMore)
+                .build();
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/repository/MessageRepository.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/repository/MessageRepository.java
@@ -24,6 +24,28 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     List<Message> findByConversationIdOrderByCreatedAtDesc(@Param("conversationId") Long conversationId);
 
     /**
+     * 대화방의 메시지 목록 커서 기반 조회 (최신순, 첫 페이지)
+     */
+    @Query("SELECT m FROM Message m " +
+           "WHERE m.conversation.id = :conversationId " +
+           "ORDER BY m.id DESC")
+    List<Message> findByConversationIdWithLimit(
+            @Param("conversationId") Long conversationId,
+            org.springframework.data.domain.Pageable pageable);
+
+    /**
+     * 대화방의 메시지 목록 커서 기반 조회 (최신순, 커서 이후)
+     */
+    @Query("SELECT m FROM Message m " +
+           "WHERE m.conversation.id = :conversationId " +
+           "AND m.id < :cursor " +
+           "ORDER BY m.id DESC")
+    List<Message> findByConversationIdWithCursor(
+            @Param("conversationId") Long conversationId,
+            @Param("cursor") Long cursor,
+            org.springframework.data.domain.Pageable pageable);
+
+    /**
      * 대화방의 안읽은 메시지 읽음 처리 (수신자 기준)
      */
     @Modifying

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/swagger/MessageControllerSwagger.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/message/message/swagger/MessageControllerSwagger.java
@@ -1,6 +1,7 @@
 package com.mzc.backend.lms.domains.message.message.swagger;
 
 import com.mzc.backend.lms.domains.message.message.dto.MessageBulkSendRequestDto;
+import com.mzc.backend.lms.domains.message.message.dto.MessageCursorResponseDto;
 import com.mzc.backend.lms.domains.message.message.dto.MessageResponseDto;
 import com.mzc.backend.lms.domains.message.message.dto.MessageSendRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,10 +24,13 @@ public interface MessageControllerSwagger {
             @Parameter(hidden = true) Long userId,
             MessageBulkSendRequestDto request);
 
-    @Operation(summary = "대화방 메시지 목록 조회", description = "대화방의 메시지 목록을 조회합니다. (최신순)")
-    ResponseEntity<List<MessageResponseDto>> getMessages(
+    @Operation(summary = "대화방 메시지 목록 조회",
+            description = "대화방의 메시지 목록을 커서 기반으로 조회합니다. (최신순, 무한스크롤)")
+    ResponseEntity<MessageCursorResponseDto> getMessages(
             @Parameter(hidden = true) Long userId,
-            @Parameter(description = "대화방 ID") Long conversationId);
+            @Parameter(description = "대화방 ID") Long conversationId,
+            @Parameter(description = "커서 (마지막 메시지 ID, 첫 페이지는 생략)") Long cursor,
+            @Parameter(description = "조회 개수 (기본값: 20)") Integer size);
 
     @Operation(summary = "메시지 삭제", description = "메시지를 삭제합니다. (소프트 삭제, 양쪽 모두 삭제 시 완전 삭제)")
     ResponseEntity<Void> deleteMessage(


### PR DESCRIPTION
## 설명
대화방 메시지 목록 조회 시 커서 기반 무한 스크롤 페이징 구현

## 변경사항
- `MessageCursorResponseDto` 추가
- `MessageRepository` 커서 쿼리 추가
- `MessageService` 커서 페이징 로직 구현
- `MessageController` cursor, size 파라미터 추가
- Swagger 문서 업데이트

## API 스펙
```
GET /api/v1/messages/conversations/{conversationId}?cursor={lastMessageId}&size=20
```

## 응답 형식
```json
{
  "messages": [...],
  "nextCursor": 123,
  "hasMore": true
}
```

## 테스트
- [x] 빌드 성공

closes #145