### PR TITLE
feat(notification): 댓글 알림 이벤트 타입 추가 refs #155

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/notification/aop/event/NotificationEventType.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/notification/aop/event/NotificationEventType.java
@@ -85,6 +85,16 @@ public enum NotificationEventType {
      */
     DISCUSSION_COMMENT_CREATED("DISCUSSION_COMMENT_CREATED", "게시판", "토론에 새 댓글이 등록되었습니다."),
 
+    /**
+     * 게시글에 댓글 등록
+     */
+    COMMENT_CREATED("COMMENT_CREATED", "게시판", "내 게시글에 새 댓글이 등록되었습니다."),
+
+    /**
+     * 댓글에 대댓글 등록
+     */
+    REPLY_CREATED("REPLY_CREATED", "게시판", "내 댓글에 답글이 등록되었습니다."),
+
     // ========== 성적 관련 ==========
     /**
      * 성적 등록/업데이트


### PR DESCRIPTION
## 목적

- 게시글 댓글/대댓글 알림 기능을 위한 이벤트 타입 추가
- 관련 이슈: #155

## 변경 요약

### 핵심 변경
- `NotificationEventType`에 새 이벤트 타입 2개 추가
  - `COMMENT_CREATED`: 내 게시글에 새 댓글이 등록되었습니다.
  - `REPLY_CREATED`: 내 댓글에 답글이 등록되었습니다.

### 주요 파일/모듈
- `domains/notification/aop/event/NotificationEventType.java`

## 수용 기준 검증

- [x] AC1: COMMENT_CREATED 이벤트 타입 추가
- [x] AC2: REPLY_CREATED 이벤트 타입 추가
- [ ] AC3: CommentService에 @NotifyEvent 적용 (후속 작업)

## 브레이킹/마이그레이션

- 없음 (이벤트 타입만 추가)

## 테스트

- 컴파일 확인 완료 (`./gradlew compileJava`)

## 참조

- refs #155