### PR TITLE
feat: 출석 API 응답에 콘텐츠별 상세 정보 추가

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/dto/ContentProgressDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/dto/ContentProgressDto.java
@@ -1,0 +1,22 @@
+package com.mzc.backend.lms.domains.attendance.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * 콘텐츠별 진행 상황 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ContentProgressDto {
+
+    private Long contentId;
+    private String title;
+    private String contentType;
+    private Boolean isCompleted;
+    private LocalDateTime completedAt;
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/dto/WeekAttendanceDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/dto/WeekAttendanceDto.java
@@ -3,6 +3,7 @@ package com.mzc.backend.lms.domains.attendance.dto;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 주차별 출석 현황 DTO
@@ -21,6 +22,7 @@ public class WeekAttendanceDto {
     private Integer completedVideoCount;
     private Integer totalVideoCount;
     private LocalDateTime completedAt;
+    private List<ContentProgressDto> contents;
 
     /**
      * 진행률 계산 (0 ~ 100)


### PR DESCRIPTION
## Summary
- 출석 조회 API 응답에 주차별 콘텐츠 상세 진행 상황 추가
- ContentProgressDto 생성
- WeekAttendanceDto에 contents 필드 추가

## Changes
- `weekAttendances[].contents` 필드 추가
  - contentId, title, contentType, isCompleted, completedAt

## Test
- 학생 출석 조회 API 테스트 완료

closes #201