### PR TITLE
feat: 학생 대시보드 API 구현

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/controller/StudentDashboardController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/controller/StudentDashboardController.java
@@ -1,0 +1,165 @@
+package com.mzc.backend.lms.domains.dashboard.student.controller;
+
+import com.mzc.backend.lms.domains.dashboard.student.dto.EnrollmentSummaryDto;
+import com.mzc.backend.lms.domains.dashboard.student.dto.NoticeDto;
+import com.mzc.backend.lms.domains.dashboard.student.dto.PendingAssignmentDto;
+import com.mzc.backend.lms.domains.dashboard.student.dto.TodayCourseDto;
+import com.mzc.backend.lms.domains.dashboard.student.service.StudentDashboardService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 학생 대시보드 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/dashboard/student")
+@RequiredArgsConstructor
+public class StudentDashboardController {
+
+    private static final int MAX_DAYS = 30;
+
+    private final StudentDashboardService studentDashboardService;
+
+    /**
+     * 미제출 과제 목록 조회
+     *
+     * @param studentId 학생 ID (JWT에서 추출)
+     * @param days 마감일 기준 일수 (기본값: 7, 최대: 30)
+     * @return 미제출 과제 목록
+     */
+    @GetMapping("/pending-assignments")
+    public ResponseEntity<?> getPendingAssignments(
+            @AuthenticationPrincipal Long studentId,
+            @RequestParam(defaultValue = "7") int days) {
+        try {
+            validateStudentId(studentId);
+            int validDays = validateDays(days);
+
+            List<PendingAssignmentDto> assignments =
+                    studentDashboardService.getPendingAssignments(studentId, validDays);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", true);
+            response.put("data", assignments);
+            response.put("count", assignments.size());
+
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(createErrorResponse(e.getMessage()));
+        } catch (Exception e) {
+            log.error("미제출 과제 목록 조회 실패: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError()
+                    .body(createErrorResponse("미제출 과제 목록 조회에 실패했습니다."));
+        }
+    }
+
+    /**
+     * 오늘의 강의 목록 조회
+     *
+     * @param studentId 학생 ID (JWT에서 추출)
+     * @return 오늘의 강의 목록
+     */
+    @GetMapping("/today-courses")
+    public ResponseEntity<?> getTodayCourses(@AuthenticationPrincipal Long studentId) {
+        try {
+            validateStudentId(studentId);
+
+            List<TodayCourseDto> courses = studentDashboardService.getTodayCourses(studentId);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", true);
+            response.put("data", courses);
+            response.put("count", courses.size());
+
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(createErrorResponse(e.getMessage()));
+        } catch (Exception e) {
+            log.error("오늘의 강의 목록 조회 실패: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError()
+                    .body(createErrorResponse("오늘의 강의 목록 조회에 실패했습니다."));
+        }
+    }
+
+    /**
+     * 최신 공지사항 목록 조회
+     *
+     * @param limit 조회할 개수 (기본값: 5, 최대: 10)
+     * @return 최신 공지사항 목록
+     */
+    @GetMapping("/notices")
+    public ResponseEntity<?> getLatestNotices(
+            @RequestParam(defaultValue = "5") int limit) {
+        try {
+            int validLimit = Math.min(Math.max(limit, 1), 10);
+
+            List<NoticeDto> notices = studentDashboardService.getLatestNotices(validLimit);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", true);
+            response.put("data", notices);
+            response.put("count", notices.size());
+
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("공지사항 목록 조회 실패: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError()
+                    .body(createErrorResponse("공지사항 목록 조회에 실패했습니다."));
+        }
+    }
+
+    /**
+     * 수강 현황 요약 조회
+     *
+     * @param studentId 학생 ID (JWT에서 추출)
+     * @return 수강 중인 과목 수와 총 학점
+     */
+    @GetMapping("/enrollment-summary")
+    public ResponseEntity<?> getEnrollmentSummary(@AuthenticationPrincipal Long studentId) {
+        try {
+            validateStudentId(studentId);
+
+            EnrollmentSummaryDto summary = studentDashboardService.getEnrollmentSummary(studentId);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", true);
+            response.put("data", summary);
+
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(createErrorResponse(e.getMessage()));
+        } catch (Exception e) {
+            log.error("수강 현황 요약 조회 실패: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError()
+                    .body(createErrorResponse("수강 현황 요약 조회에 실패했습니다."));
+        }
+    }
+
+    private void validateStudentId(Long studentId) {
+        if (studentId == null) {
+            throw new IllegalArgumentException("인증이 필요합니다.");
+        }
+    }
+
+    private int validateDays(int days) {
+        return Math.min(Math.max(days, 1), MAX_DAYS);
+    }
+
+    private Map<String, Object> createErrorResponse(String message) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("success", false);
+        response.put("message", message);
+        return response;
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/dto/EnrollmentSummaryDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/dto/EnrollmentSummaryDto.java
@@ -1,0 +1,19 @@
+package com.mzc.backend.lms.domains.dashboard.student.dto;
+
+import lombok.Getter;
+
+/**
+ * 수강 현황 요약 DTO
+ * 수강 중인 과목 수와 총 학점
+ */
+@Getter
+public class EnrollmentSummaryDto {
+
+    private final Integer courseCount;
+    private final Integer totalCredits;
+
+    public EnrollmentSummaryDto(Number courseCount, Number totalCredits) {
+        this.courseCount = courseCount != null ? courseCount.intValue() : 0;
+        this.totalCredits = totalCredits != null ? totalCredits.intValue() : 0;
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/dto/NoticeDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/dto/NoticeDto.java
@@ -1,0 +1,25 @@
+package com.mzc.backend.lms.domains.dashboard.student.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 공지사항 응답 DTO
+ * 대시보드용 최신 공지사항 정보
+ */
+@Getter
+public class NoticeDto {
+
+    private final Long id;
+    private final String title;
+    private final LocalDateTime createdAt;
+    private final Integer viewCount;
+
+    public NoticeDto(Long id, String title, LocalDateTime createdAt, Integer viewCount) {
+        this.id = id;
+        this.title = title;
+        this.createdAt = createdAt;
+        this.viewCount = viewCount;
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/dto/PendingAssignmentDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/dto/PendingAssignmentDto.java
@@ -1,0 +1,52 @@
+package com.mzc.backend.lms.domains.dashboard.student.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * 미제출 과제 응답 DTO
+ */
+@Getter
+public class PendingAssignmentDto {
+
+    private final Long assignmentId;
+    private final Long postId;
+    private final String title;
+    private final Long courseId;
+    private final String courseName;
+    private final String subjectName;
+    private final LocalDateTime dueDate;
+    private final Boolean lateSubmissionAllowed;
+
+    /**
+     * JPQL 생성자
+     */
+    public PendingAssignmentDto(
+            Long assignmentId,
+            Long postId,
+            String title,
+            Long courseId,
+            String courseName,
+            String subjectName,
+            LocalDateTime dueDate,
+            Boolean lateSubmissionAllowed
+    ) {
+        this.assignmentId = assignmentId;
+        this.postId = postId;
+        this.title = title;
+        this.courseId = courseId;
+        this.courseName = courseName;
+        this.subjectName = subjectName;
+        this.dueDate = dueDate;
+        this.lateSubmissionAllowed = lateSubmissionAllowed;
+    }
+
+    /**
+     * 남은 일수 계산
+     */
+    public Long getDaysRemaining() {
+        return ChronoUnit.DAYS.between(LocalDateTime.now(), dueDate);
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/dto/TodayCourseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/dto/TodayCourseDto.java
@@ -1,0 +1,61 @@
+package com.mzc.backend.lms.domains.dashboard.student.dto;
+
+import com.mzc.backend.lms.domains.user.auth.encryption.annotation.Encrypted;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 오늘의 강의 응답 DTO
+ * 기존 MyEnrollmentsResponseDto.EnrollmentItemDto와 동일한 구조
+ */
+@Getter
+@Builder
+public class TodayCourseDto {
+
+    private Long enrollmentId;
+    private CourseInfoDto course;
+    private ProfessorDto professor;
+    private List<ScheduleDto> schedule;
+
+    @Getter
+    @Builder
+    public static class CourseInfoDto {
+        private Long id;
+        private String courseCode;
+        private String courseName;
+        private String section;
+        private Integer credits;
+        private CourseTypeDto courseType;
+        private Integer currentStudents;
+        private Integer maxStudents;
+    }
+
+    @Getter
+    @Builder
+    public static class ProfessorDto {
+        private Long id;
+
+        @Encrypted
+        private String name;
+    }
+
+    @Getter
+    @Builder
+    public static class ScheduleDto {
+        private Integer dayOfWeek;
+        private String dayName;
+        private String startTime;
+        private String endTime;
+        private String classroom;
+    }
+
+    @Getter
+    @Builder
+    public static class CourseTypeDto {
+        private String code;
+        private String name;
+        private String color;
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/event/LoginEventListener.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/event/LoginEventListener.java
@@ -1,0 +1,98 @@
+package com.mzc.backend.lms.domains.dashboard.student.event;
+
+import com.mzc.backend.lms.domains.dashboard.student.dto.TodayCourseDto;
+import com.mzc.backend.lms.domains.dashboard.student.service.DailyLoginService;
+import com.mzc.backend.lms.domains.dashboard.student.service.StudentDashboardService;
+import com.mzc.backend.lms.domains.notification.entity.NotificationType;
+import com.mzc.backend.lms.domains.notification.queue.dto.NotificationMessage;
+import com.mzc.backend.lms.domains.notification.queue.service.NotificationQueueService;
+import com.mzc.backend.lms.domains.notification.repository.NotificationTypeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 로그인 이벤트 리스너
+ * 오늘 첫 로그인 시 수업 알림 발송
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LoginEventListener {
+
+    private static final String NOTIFICATION_TYPE_CODE = "DAILY_COURSE_REMINDER";
+
+    private final DailyLoginService dailyLoginService;
+    private final StudentDashboardService studentDashboardService;
+    private final NotificationQueueService notificationQueueService;
+    private final NotificationTypeRepository notificationTypeRepository;
+
+    @Async
+    @EventListener
+    public void handleLoginSuccess(LoginSuccessEvent event) {
+        // 학생만 처리
+        if (!"STUDENT".equals(event.getUserType())) {
+            return;
+        }
+
+        Long studentId = event.getUserId();
+
+        // 오늘 첫 로그인 확인
+        if (!dailyLoginService.checkAndMarkFirstLoginToday(studentId)) {
+            return;
+        }
+
+        // 오늘 강의 조회
+        List<TodayCourseDto> todayCourses = studentDashboardService.getTodayCourses(studentId);
+
+        if (todayCourses.isEmpty()) {
+            log.debug("오늘 수업 없음: studentId={}", studentId);
+            return;
+        }
+
+        // 알림 발송
+        sendTodayCoursesNotification(studentId, todayCourses);
+    }
+
+    private void sendTodayCoursesNotification(Long studentId, List<TodayCourseDto> courses) {
+        NotificationType notificationType = notificationTypeRepository
+                .findByTypeCode(NOTIFICATION_TYPE_CODE)
+                .orElse(null);
+
+        if (notificationType == null) {
+            log.warn("알림 타입을 찾을 수 없음: typeCode={}", NOTIFICATION_TYPE_CODE);
+            return;
+        }
+
+        String courseList = courses.stream()
+                .map(c -> {
+                    String schedule = c.getSchedule().isEmpty() ? "" :
+                            c.getSchedule().get(0).getStartTime() + " - " +
+                            c.getSchedule().get(0).getEndTime() + ", " +
+                            c.getSchedule().get(0).getClassroom();
+                    return String.format("- %s (%s)", c.getCourse().getCourseName(), schedule);
+                })
+                .collect(Collectors.joining("\n"));
+
+        String message = String.format("오늘 %d개의 수업이 있습니다.\n%s",
+                courses.size(), courseList);
+
+        NotificationMessage notificationMessage = NotificationMessage.builder()
+                .typeId(notificationType.getId())
+                .senderId(null)
+                .recipientId(studentId)
+                .title("오늘의 수업 안내")
+                .message(message)
+                .actionUrl("/dashboard")
+                .build();
+
+        notificationQueueService.enqueue(notificationMessage);
+
+        log.info("오늘의 수업 알림 발송: studentId={}, courseCount={}", studentId, courses.size());
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/event/LoginSuccessEvent.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/event/LoginSuccessEvent.java
@@ -1,0 +1,23 @@
+package com.mzc.backend.lms.domains.dashboard.student.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 로그인 성공 이벤트
+ * 로그인 성공 시 발행되어 오늘의 수업 알림 발송에 사용됨
+ */
+@Getter
+@AllArgsConstructor
+public class LoginSuccessEvent {
+
+    /**
+     * 로그인한 사용자 ID
+     */
+    private final Long userId;
+
+    /**
+     * 사용자 타입 (STUDENT, PROFESSOR)
+     */
+    private final String userType;
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/repository/DashboardQueryRepository.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/repository/DashboardQueryRepository.java
@@ -1,0 +1,167 @@
+package com.mzc.backend.lms.domains.dashboard.student.repository;
+
+import com.mzc.backend.lms.domains.board.enums.BoardType;
+import com.mzc.backend.lms.domains.dashboard.student.dto.EnrollmentSummaryDto;
+import com.mzc.backend.lms.domains.dashboard.student.dto.NoticeDto;
+import com.mzc.backend.lms.domains.dashboard.student.dto.PendingAssignmentDto;
+import com.mzc.backend.lms.domains.enrollment.entity.Enrollment;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 대시보드 전용 조회 Repository
+ * EntityManager + JPQL 기반
+ */
+@Repository
+@RequiredArgsConstructor
+public class DashboardQueryRepository {
+
+    private final EntityManager em;
+
+    /**
+     * 미제출 과제 목록 조회
+     * - 학생이 수강 중인 과목의 과제
+     * - 마감일이 현재 ~ 지정된 기한 이내
+     * - 아직 제출하지 않은 과제
+     *
+     * @param studentId 학생 ID
+     * @param withinDays 마감일 기준 일수 (예: 7일 이내)
+     * @return 미제출 과제 목록
+     */
+    public List<PendingAssignmentDto> findPendingAssignments(Long studentId, int withinDays) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime deadline = now.plusDays(withinDays);
+
+        String jpql = """
+            SELECT new com.mzc.backend.lms.domains.dashboard.student.dto.PendingAssignmentDto(
+                a.id,
+                p.id,
+                p.title,
+                c.id,
+                CONCAT(s.subjectName, ' - ', c.sectionNumber),
+                s.subjectName,
+                a.dueDate,
+                a.lateSubmissionAllowed
+            )
+            FROM Assignment a
+            JOIN a.post p
+            JOIN Course c ON a.courseId = c.id
+            JOIN c.subject s
+            WHERE a.courseId IN (
+                SELECT e.course.id FROM Enrollment e WHERE e.student.studentId = :studentId
+            )
+            AND a.dueDate > :now
+            AND a.dueDate <= :deadline
+            AND a.isDeleted = false
+            AND NOT EXISTS (
+                SELECT 1 FROM AssignmentSubmission sub
+                WHERE sub.assignment.id = a.id
+                AND sub.userId = :studentId
+                AND sub.isDeleted = false
+            )
+            ORDER BY a.dueDate ASC
+            """;
+
+        TypedQuery<PendingAssignmentDto> query = em.createQuery(jpql, PendingAssignmentDto.class);
+        query.setParameter("studentId", studentId);
+        query.setParameter("now", now);
+        query.setParameter("deadline", deadline);
+
+        return query.getResultList();
+    }
+
+    /**
+     * 오늘의 강의 목록 조회
+     * - 학생이 수강 중인 과목
+     * - 오늘 요일에 해당하는 강의
+     *
+     * @param studentId 학생 ID
+     * @return 오늘 수업이 있는 Enrollment 목록
+     */
+    public List<Enrollment> findTodayEnrollments(Long studentId) {
+        DayOfWeek today = LocalDate.now().getDayOfWeek();
+
+        String jpql = """
+            SELECT DISTINCT e
+            FROM Enrollment e
+            JOIN FETCH e.course c
+            JOIN FETCH c.subject s
+            JOIN FETCH c.professor p
+            JOIN FETCH p.user u
+            LEFT JOIN FETCH u.userProfile up
+            JOIN FETCH c.schedules cs
+            WHERE e.student.studentId = :studentId
+            AND cs.dayOfWeek = :today
+            """;
+
+        TypedQuery<Enrollment> query = em.createQuery(jpql, Enrollment.class);
+        query.setParameter("studentId", studentId);
+        query.setParameter("today", today);
+
+        return query.getResultList();
+    }
+
+    /**
+     * 최신 공지사항 목록 조회
+     * - 학교 공지사항 게시판의 게시글
+     * - 삭제되지 않은 게시글
+     * - 최신순 정렬
+     *
+     * @param limit 조회할 개수 (기본값: 5)
+     * @return 최신 공지사항 목록
+     */
+    public List<NoticeDto> findLatestNotices(int limit) {
+        String jpql = """
+            SELECT new com.mzc.backend.lms.domains.dashboard.student.dto.NoticeDto(
+                p.id,
+                p.title,
+                p.createdAt,
+                p.viewCount
+            )
+            FROM Post p
+            JOIN p.category c
+            WHERE c.boardType = :boardType
+            AND p.isDeleted = false
+            ORDER BY p.createdAt DESC
+            """;
+
+        TypedQuery<NoticeDto> query = em.createQuery(jpql, NoticeDto.class);
+        query.setParameter("boardType", BoardType.NOTICE);
+        query.setMaxResults(limit);
+
+        return query.getResultList();
+    }
+
+    /**
+     * 수강 현황 요약 조회
+     * - 수강 중인 과목 수
+     * - 수강 중인 총 학점
+     *
+     * @param studentId 학생 ID
+     * @return 수강 현황 요약
+     */
+    public EnrollmentSummaryDto findEnrollmentSummary(Long studentId) {
+        String jpql = """
+            SELECT new com.mzc.backend.lms.domains.dashboard.student.dto.EnrollmentSummaryDto(
+                COUNT(e),
+                COALESCE(SUM(s.credits), 0)
+            )
+            FROM Enrollment e
+            JOIN e.course c
+            JOIN c.subject s
+            WHERE e.student.studentId = :studentId
+            """;
+
+        TypedQuery<EnrollmentSummaryDto> query = em.createQuery(jpql, EnrollmentSummaryDto.class);
+        query.setParameter("studentId", studentId);
+
+        return query.getSingleResult();
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/service/DailyLoginService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/service/DailyLoginService.java
@@ -1,0 +1,69 @@
+package com.mzc.backend.lms.domains.dashboard.student.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+/**
+ * 일일 로그인 확인 서비스
+ * Redis를 사용하여 오늘 첫 로그인 여부를 확인
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DailyLoginService {
+
+    private static final String KEY_PREFIX = "daily_login:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * 오늘 첫 로그인인지 확인하고, 첫 로그인이면 마킹
+     *
+     * @param userId 사용자 ID
+     * @return true: 오늘 첫 로그인, false: 이미 로그인한 적 있음
+     */
+    public boolean checkAndMarkFirstLoginToday(Long userId) {
+        String key = buildKey(userId);
+
+        Boolean isFirstLogin = redisTemplate.opsForValue().setIfAbsent(key, "1", calculateTtl());
+
+        if (Boolean.TRUE.equals(isFirstLogin)) {
+            log.debug("오늘 첫 로그인: userId={}", userId);
+            return true;
+        }
+
+        log.debug("오늘 이미 로그인함: userId={}", userId);
+        return false;
+    }
+
+    /**
+     * 오늘 로그인 여부만 확인 (마킹 없이)
+     *
+     * @param userId 사용자 ID
+     * @return true: 오늘 로그인한 적 있음, false: 오늘 첫 로그인
+     */
+    public boolean hasLoggedInToday(Long userId) {
+        String key = buildKey(userId);
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    private String buildKey(Long userId) {
+        return KEY_PREFIX + userId + ":" + LocalDate.now();
+    }
+
+    /**
+     * 자정까지 남은 시간 계산
+     */
+    private Duration calculateTtl() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime midnight = LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.MIDNIGHT);
+        return Duration.between(now, midnight);
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/service/StudentDashboardService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/service/StudentDashboardService.java
@@ -1,0 +1,157 @@
+package com.mzc.backend.lms.domains.dashboard.student.service;
+
+import com.mzc.backend.lms.domains.dashboard.student.dto.EnrollmentSummaryDto;
+import com.mzc.backend.lms.domains.dashboard.student.dto.NoticeDto;
+import com.mzc.backend.lms.domains.dashboard.student.dto.PendingAssignmentDto;
+import com.mzc.backend.lms.domains.dashboard.student.dto.TodayCourseDto;
+import com.mzc.backend.lms.domains.dashboard.student.repository.DashboardQueryRepository;
+import com.mzc.backend.lms.domains.course.course.entity.Course;
+import com.mzc.backend.lms.domains.course.course.entity.CourseSchedule;
+import com.mzc.backend.lms.domains.enrollment.entity.Enrollment;
+import com.mzc.backend.lms.domains.user.professor.entity.Professor;
+import com.mzc.backend.lms.domains.user.profile.entity.UserProfile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.TextStyle;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * 학생 대시보드 서비스
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudentDashboardService {
+
+    private static final int DEFAULT_PENDING_DAYS = 7;
+    private static final int DEFAULT_NOTICE_LIMIT = 5;
+
+    private final DashboardQueryRepository dashboardQueryRepository;
+
+    /**
+     * 미제출 과제 목록 조회 (기본 7일 이내)
+     *
+     * @param studentId 학생 ID
+     * @return 미제출 과제 목록
+     */
+    public List<PendingAssignmentDto> getPendingAssignments(Long studentId) {
+        return getPendingAssignments(studentId, DEFAULT_PENDING_DAYS);
+    }
+
+    /**
+     * 미제출 과제 목록 조회 (기간 지정)
+     *
+     * @param studentId 학생 ID
+     * @param withinDays 마감일 기준 일수
+     * @return 미제출 과제 목록
+     */
+    public List<PendingAssignmentDto> getPendingAssignments(Long studentId, int withinDays) {
+        return dashboardQueryRepository.findPendingAssignments(studentId, withinDays);
+    }
+
+    /**
+     * 최신 공지사항 목록 조회 (기본 5개)
+     *
+     * @return 최신 공지사항 목록
+     */
+    public List<NoticeDto> getLatestNotices() {
+        return getLatestNotices(DEFAULT_NOTICE_LIMIT);
+    }
+
+    /**
+     * 최신 공지사항 목록 조회 (개수 지정)
+     *
+     * @param limit 조회할 개수
+     * @return 최신 공지사항 목록
+     */
+    public List<NoticeDto> getLatestNotices(int limit) {
+        return dashboardQueryRepository.findLatestNotices(limit);
+    }
+
+    /**
+     * 수강 현황 요약 조회
+     *
+     * @param studentId 학생 ID
+     * @return 수강 현황 요약 (과목 수, 총 학점)
+     */
+    public EnrollmentSummaryDto getEnrollmentSummary(Long studentId) {
+        return dashboardQueryRepository.findEnrollmentSummary(studentId);
+    }
+
+    /**
+     * 오늘의 강의 목록 조회
+     *
+     * @param studentId 학생 ID
+     * @return 오늘의 강의 목록
+     */
+    public List<TodayCourseDto> getTodayCourses(Long studentId) {
+        List<Enrollment> enrollments = dashboardQueryRepository.findTodayEnrollments(studentId);
+        DayOfWeek today = LocalDate.now().getDayOfWeek();
+
+        return enrollments.stream()
+                .map(e -> toTodayCourseDto(e, today))
+                .sorted(Comparator.comparing(dto ->
+                    dto.getSchedule().isEmpty() ? "" : dto.getSchedule().get(0).getStartTime()))
+                .toList();
+    }
+
+    private TodayCourseDto toTodayCourseDto(Enrollment enrollment, DayOfWeek today) {
+        Course course = enrollment.getCourse();
+        Professor professor = course.getProfessor();
+        UserProfile professorProfile = professor.getUser().getUserProfile();
+
+        // 오늘 요일에 해당하는 스케줄만 필터링
+        List<TodayCourseDto.ScheduleDto> todaySchedules = course.getSchedules().stream()
+                .filter(s -> s.getDayOfWeek() == today)
+                .map(this::toScheduleDto)
+                .sorted(Comparator.comparing(TodayCourseDto.ScheduleDto::getStartTime))
+                .toList();
+
+        return TodayCourseDto.builder()
+                .enrollmentId(enrollment.getId())
+                .course(TodayCourseDto.CourseInfoDto.builder()
+                        .id(course.getId())
+                        .courseCode(course.getSubject().getSubjectCode())
+                        .courseName(course.getSubject().getSubjectName())
+                        .section(course.getSectionNumber())
+                        .credits(course.getSubject().getCredits())
+                        .courseType(toCourseTypeDto(course))
+                        .currentStudents(course.getCurrentStudents())
+                        .maxStudents(course.getMaxStudents())
+                        .build())
+                .professor(TodayCourseDto.ProfessorDto.builder()
+                        .id(professor.getProfessorId())
+                        .name(professorProfile != null ? professorProfile.getName() : null)
+                        .build())
+                .schedule(todaySchedules)
+                .build();
+    }
+
+    private TodayCourseDto.ScheduleDto toScheduleDto(CourseSchedule schedule) {
+        return TodayCourseDto.ScheduleDto.builder()
+                .dayOfWeek(schedule.getDayOfWeek().getValue())
+                .dayName(schedule.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN))
+                .startTime(schedule.getStartTime().toString())
+                .endTime(schedule.getEndTime().toString())
+                .classroom(schedule.getScheduleRoom())
+                .build();
+    }
+
+    private TodayCourseDto.CourseTypeDto toCourseTypeDto(Course course) {
+        var courseType = course.getSubject().getCourseType();
+        if (courseType == null) {
+            return null;
+        }
+        return TodayCourseDto.CourseTypeDto.builder()
+                .code(courseType.getTypeCodeString())
+                .name(courseType.getTypeName())
+                .color(courseType.getColor())
+                .build();
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/usecase/impl/LoginUseCaseImpl.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/usecase/impl/LoginUseCaseImpl.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.user.auth.usecase.impl;
 
+import com.mzc.backend.lms.domains.dashboard.student.event.LoginSuccessEvent;
 import com.mzc.backend.lms.domains.user.auth.dto.LoginRequestDto;
 import com.mzc.backend.lms.domains.user.auth.dto.LoginResponseDto;
 import com.mzc.backend.lms.domains.user.auth.encryption.service.EncryptionService;
@@ -19,6 +20,7 @@ import com.mzc.backend.lms.domains.user.user.entity.User;
 import com.mzc.backend.lms.domains.user.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +44,7 @@ public class LoginUseCaseImpl implements LoginUseCase {
     private final EncryptionService encryptionService;
     private final JwtTokenService jwtTokenService;
     private final com.mzc.backend.lms.domains.user.student.repository.StudentDepartmentRepository studentDepartmentRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -87,8 +90,11 @@ public class LoginUseCaseImpl implements LoginUseCase {
             }
         }
 
-        log.info("로그인 성공: userId={}, userType={}, departmentId={}, departmentName={}", 
+        log.info("로그인 성공: userId={}, userType={}, departmentId={}, departmentName={}",
                 user.getId(), userInfo.userType, departmentId, departmentName);
+
+        // 로그인 성공 이벤트 발행
+        eventPublisher.publishEvent(new LoginSuccessEvent(user.getId(), userInfo.userType));
 
         return LoginResponseDto.of(
             accessToken,

--- a/springboot/src/main/resources/db/migration/V20__add_daily_course_notification_type.sql
+++ b/springboot/src/main/resources/db/migration/V20__add_daily_course_notification_type.sql
@@ -1,0 +1,6 @@
+-- -----------------------------------------------------
+-- V20: 오늘의 수업 알림 타입 추가
+-- -----------------------------------------------------
+
+INSERT INTO notification_types (type_code, type_name, category, default_message_template, is_active) VALUES
+('DAILY_COURSE_REMINDER', '오늘의 수업 알림', '수업', '오늘 수강해야 할 수업이 있습니다.', true);


### PR DESCRIPTION
## Summary
- 학생 대시보드용 API 4종 구현
- 로그인 시 오늘 수업 알림 발송 기능 추가

## 구현 내용

### API 엔드포인트
| 엔드포인트 | 설명 |
|-----------|------|
| `GET /api/v1/dashboard/student/pending-assignments` | 미제출 과제 목록 (7일 이내 마감) |
| `GET /api/v1/dashboard/student/today-courses` | 오늘의 강의 목록 |
| `GET /api/v1/dashboard/student/notices` | 최신 공지사항 (5개) |
| `GET /api/v1/dashboard/student/enrollment-summary` | 수강 현황 요약 (과목 수, 총 학점) |

### 로그인 알림
- Redis 기반 일일 첫 로그인 체크
- 오늘 수업이 있는 경우 알림 자동 발송

## 파일 구조
```
domains/dashboard/student/
├── controller/
│   └── StudentDashboardController.java
├── dto/
│   ├── EnrollmentSummaryDto.java
│   ├── NoticeDto.java
│   ├── PendingAssignmentDto.java
│   └── TodayCourseDto.java
├── event/
│   ├── LoginEventListener.java
│   └── LoginSuccessEvent.java
├── repository/
│   └── DashboardQueryRepository.java
└── service/
    ├── DailyLoginService.java
    └── StudentDashboardService.java
```

## Test plan
- [ ] 미제출 과제 목록 조회 테스트
- [ ] 오늘의 강의 목록 조회 테스트
- [ ] 공지사항 목록 조회 테스트
- [ ] 수강 현황 요약 조회 테스트
- [ ] 로그인 시 알림 발송 테스트

closes #207