### PR TITLE
[HOTFIX] 프로필 이미지 URL 및 서빙 포트 수정

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -27,3 +27,4 @@ ENCRYPTION_IV=defaultIvParam456
 
 # Server Configuration
 SERVER_PORT=8080
+APP_SERVER_URL=http://localhost:8080

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,7 +5,6 @@ services:
     container_name: lms-nginx
     restart: unless-stopped
     ports:
-      - "80:80"
       - "8080:8080"
       - "8090:8090"
     volumes:
@@ -94,7 +93,7 @@ services:
       JWT_REFRESH_TOKEN_EXPIRATION_TIME: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
       ENCRYPTION_IV: ${ENCRYPTION_IV}
-      APP_SERVER_URL: http://nginx
+      APP_SERVER_URL: ${APP_SERVER_URL:-http://localhost:8080}
     depends_on:
       mysql:
         condition: service_healthy
@@ -136,7 +135,7 @@ services:
       JWT_REFRESH_TOKEN_EXPIRATION_TIME: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
       ENCRYPTION_IV: ${ENCRYPTION_IV}
-      APP_SERVER_URL: http://nginx
+      APP_SERVER_URL: ${APP_SERVER_URL:-http://localhost:8080}
     depends_on:
       mysql:
         condition: service_healthy
@@ -178,7 +177,7 @@ services:
       JWT_REFRESH_TOKEN_EXPIRATION_TIME: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
       ENCRYPTION_IV: ${ENCRYPTION_IV}
-      APP_SERVER_URL: http://nginx
+      APP_SERVER_URL: ${APP_SERVER_URL:-http://localhost:8080}
     depends_on:
       mysql:
         condition: service_healthy

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -33,23 +33,25 @@ http {
         server video-server-3:8080;
     }
 
-    # Port 80 - Static Files (Profile Images)
+    # Port 8080 - API Server + Static Files (Load Balanced)
     server {
-        listen 80;
+        listen 8080;
         server_name localhost;
 
         client_max_body_size 50M;
 
-        # Static files - Profile images
+        # Static files - Profile images (served directly by nginx)
         location /static/profile/ {
-            alias /var/www/uploads/;
+            alias /var/www/uploads/files/;
             expires 30d;
             add_header Cache-Control "public, immutable";
             add_header X-Content-Type-Options "nosniff";
+            add_header Access-Control-Allow-Origin *;
 
             location ~* \.(webp|jpg|jpeg|png|gif)$ {
                 expires 30d;
                 add_header Cache-Control "public, immutable";
+                add_header Access-Control-Allow-Origin *;
             }
         }
 
@@ -59,20 +61,7 @@ http {
             add_header Content-Type text/plain;
         }
 
-        # Default - 404
-        location / {
-            return 404;
-        }
-    }
-
-    # Port 8080 - API Server (Load Balanced)
-    server {
-        listen 8080;
-        server_name localhost;
-
-        client_max_body_size 50M;
-
-        # API requests
+        # API requests (proxy to Spring Boot)
         location / {
             proxy_pass http://spring-app;
             proxy_set_header Host $host;


### PR DESCRIPTION
## Summary
- 프로필 이미지 URL이 `http://nginx/...`로 저장되어 외부 접근 불가 문제 해결
- 80 포트 제거, 8080 포트에서 API + 정적 파일 통합 서빙

## Changes
- `docker-compose.prod.yml`: 80 포트 제거, APP_SERVER_URL 환경변수화
- `nginx/nginx.prod.conf`: 8080 포트에서 `/static/profile/` 경로 추가 (CORS 헤더 포함)
- `.env.prod`: APP_SERVER_URL 추가

## 이미지 URL 형식
```
http://localhost:8080/static/profile/images/2025/12/22/filename.webp
```

## Test plan
- [ ] 프로필 이미지 업로드 후 URL 확인
- [ ] 8080 포트에서 이미지 접근 확인
- [ ] CORS 헤더 확인

closes #216
