### PR TITLE
hotfix: Video Server 로드밸런싱 ip_hash로 변경

### DIFF
--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -25,9 +25,9 @@ http {
         server spring-app-3:8080;
     }
 
-    # Load Balancing - Video Server (least_conn)
+    # Load Balancing - Video Server (ip_hash for TUS upload consistency)
     upstream video-server {
-        least_conn;
+        ip_hash;
         server video-server-1:8080;
         server video-server-2:8080;
         server video-server-3:8080;


### PR DESCRIPTION
## Summary
- Video Server 로드밸런싱 방식을 `least_conn`에서 `ip_hash`로 변경
- TUS 업로드 일관성 유지를 위한 변경

## Changes
- `nginx/nginx.prod.conf`: Video Server upstream 설정 변경

## Test plan
- [ ] Video 업로드 테스트