### PR TITLE
chore: 로그 로테이션 설정 추가

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,6 +10,11 @@ services:
     volumes:
       - ./nginx/nginx.prod.conf:/etc/nginx/nginx.conf:ro
       - ./uploads:/var/www/uploads:ro
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
     depends_on:
       spring-app-1:
         condition: service_healthy
@@ -33,6 +38,11 @@ services:
     restart: unless-stopped
     ports:
       - "3306:3306"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
     environment:
       MYSQL_ROOT_PASSWORD: ${DATABASE_ROOT_PASSWORD:-rootpassword}
       MYSQL_DATABASE: ${DATABASE_NAME}
@@ -58,6 +68,11 @@ services:
     restart: unless-stopped
     ports:
       - "6379:6379"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
     command: redis-server --appendonly yes
     volumes:
       - redis-data:/data
@@ -74,6 +89,11 @@ services:
     image: ddingsh9/mzc-core-api:latest
     container_name: lms-spring-app-1
     restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
     environment:
       DATABASE_URL: mysql
       DATABASE_PORT: ${DATABASE_PORT}
@@ -116,6 +136,11 @@ services:
     image: ddingsh9/mzc-core-api:latest
     container_name: lms-spring-app-2
     restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
     environment:
       DATABASE_URL: mysql
       DATABASE_PORT: ${DATABASE_PORT}
@@ -158,6 +183,11 @@ services:
     image: ddingsh9/mzc-core-api:latest
     container_name: lms-spring-app-3
     restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
     environment:
       DATABASE_URL: mysql
       DATABASE_PORT: ${DATABASE_PORT}
@@ -200,6 +230,11 @@ services:
     image: ddingsh9/mzc-video-server:latest
     container_name: lms-video-server-1
     restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
     environment:
       SERVER_PORT: 8080
       DATABASE_URL: mysql
@@ -233,6 +268,11 @@ services:
     image: ddingsh9/mzc-video-server:latest
     container_name: lms-video-server-2
     restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
     environment:
       SERVER_PORT: 8080
       DATABASE_URL: mysql
@@ -266,6 +306,11 @@ services:
     image: ddingsh9/mzc-video-server:latest
     container_name: lms-video-server-3
     restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
     environment:
       SERVER_PORT: 8080
       DATABASE_URL: mysql


### PR DESCRIPTION
## Summary
- 모든 Docker 서비스에 로그 로테이션 설정 추가
- max-size: 50MB, max-file: 5개 (오래된 로그 자동 삭제)

## 적용 서비스
nginx, mysql, redis, spring-app-1~3, video-server-1~3